### PR TITLE
Fix version dependencies in the plugin

### DIFF
--- a/org.scala-ide.play2/META-INF/MANIFEST.MF
+++ b/org.scala-ide.play2/META-INF/MANIFEST.MF
@@ -23,10 +23,10 @@ Require-Bundle:
  org.eclipse.ui.ide,
  org.scala-ide.scala.library,
  org.scala-ide.scala.compiler,
- org.scala-ide.sdt.core;bundle-version="[2.0.0,2.2.0)",
- org.eclipse.core.resources;bundle-version="3.7.101",
+ org.scala-ide.sdt.core;bundle-version="[2.0.3,2.2.0)",
+ org.eclipse.core.resources,
  scalariform,
- org.eclipse.core.filesystem;bundle-version="1.3.100"
+ org.eclipse.core.filesystem
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse;apply-aspects:=false,


### PR DESCRIPTION
Removed versioned dependencies on Eclipse plugins, since they aren't necessary, and they are too restrictive.

Bumped up the sdt.core dependency so that people don't install it against the stable version (it won't work).
