### PR TITLE
Fixed compilation failure

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/PlayPlugin.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/PlayPlugin.scala
@@ -8,14 +8,16 @@ import org.eclipse.core.resources.ResourcesPlugin
 
 object PlayPlugin {
   @volatile var plugin: PlayPlugin = _
-  val PLUGIN_ID = "org.scala-ide.play2"
 
-  def getDefault = PlayPlugin.plugin
+  private final val PluginId = "org.scala-ide.play2"
+  final val ProblemMarkerId = PluginId + ".templateProblem"
+  final val RouteFormatterMarginId = PluginId + ".routeeditor.margin"
+  final val TemplateExtension = "scala.html"
 
   def prefStore = plugin.getPreferenceStore
 
   def getImageDescriptor(path: String) = {
-    AbstractUIPlugin.imageDescriptorFromPlugin(PLUGIN_ID, path);
+    AbstractUIPlugin.imageDescriptorFromPlugin(PluginId, path);
   }
 }
 
@@ -31,10 +33,6 @@ class PlayPlugin extends AbstractUIPlugin {
     PlayPlugin.plugin = null;
     super.stop(context);
   }
-
-  val problemMarkerId = PLUGIN_ID + ".templateProblem"
-  val templateExtension = ".scala.html"
-  val routeFormatterMarginId = PLUGIN_ID + ".routeeditor.margin"
 
   def asPlayProject(project: IProject): Option[PlayProject] = {
     val scalaProject = ScalaPlugin.plugin.asScalaProject(project)

--- a/org.scala-ide.play2/src/org/scalaide/play2/PlayProject.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/PlayProject.scala
@@ -27,8 +27,8 @@ class PlayProject private (val scalaProject: ScalaProject) {
    */
   def initialize() {
     val templateCompilationUnits = for (
-      r <- scalaProject.underlying.members() if r.isInstanceOf[IFile] if r.getFullPath().toString().endsWith(PlayPlugin.plugin.templateExtension)
-    )  yield TemplateCompilationUnit.fromFile(r.asInstanceOf[IFile])
+      r <- scalaProject.underlying.members() if r.isInstanceOf[IFile] if r.getFullPath().toString().endsWith("." + PlayPlugin.TemplateExtension)
+    )  yield TemplateCompilationUnit(r.asInstanceOf[IFile])
     templateCompilationUnits foreach (_.askReload())
     templateCompilationUnits.reverse foreach (_.askReload())
     // FIXME not works!!!

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/formatter/RouteFormattingStrategy.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/formatter/RouteFormattingStrategy.scala
@@ -128,7 +128,7 @@ class RouteFormattingStrategy(val editor: ITextEditor) extends IFormattingStrate
   def format() {
     val regions = RoutePartitionTokeniser.tokenise(document.get)
     val lines = getRoutes(regions)
-    val margin = PlayPlugin.prefStore.getInt(PlayPlugin.plugin.routeFormatterMarginId)
+    val margin = PlayPlugin.prefStore.getInt(PlayPlugin.RouteFormatterMarginId)
     val maxHttpVerbLength = (lines map (_.httpVerb.get.length)).max + margin
     val maxUriLength = (lines map (_.uri.get.length)).max + margin
     val eclipseEdits = lines flatMap { route =>

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/properties/RouteColourPreferenceInitializer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/properties/RouteColourPreferenceInitializer.scala
@@ -16,7 +16,7 @@ class RouteColourPreferenceInitializer extends AbstractPreferenceInitializer {
   private def doInitializeDefaultPreferences() {
     val prefStore = PlayPlugin.prefStore
     setDefaultsForSyntaxClasses(prefStore)
-    prefStore.setDefault(PlayPlugin.plugin.routeFormatterMarginId, 3) // for formatter
+    prefStore.setDefault(PlayPlugin.RouteFormatterMarginId, 3) // for formatter
   }
 
   private def setDefaultsForSyntaxClass(

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/properties/RouteFormatterPreferencePage.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/properties/RouteFormatterPreferencePage.scala
@@ -11,7 +11,7 @@ class RouteFormatterPreferencePage extends FieldEditorPreferencePage with IWorkb
   setPreferenceStore(PlayPlugin.plugin.getPreferenceStore)
   
   override def createFieldEditors() {
-    val marginField = new IntegerFieldEditor(PlayPlugin.plugin.routeFormatterMarginId, "Number of spaces between columns", getFieldEditorParent)
+    val marginField = new IntegerFieldEditor(PlayPlugin.RouteFormatterMarginId, "Number of spaces between columns", getFieldEditorParent)
     marginField.setValidRange(1, 10)
     addField(marginField)
   }

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateConfiguration.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateConfiguration.scala
@@ -33,6 +33,7 @@ import org.eclipse.jface.text.IDocument
 import org.scalaide.play2.properties.PropertyChangeHandler
 import org.scalaide.play2.templateeditor.lexical.TemplateDefaultScanner
 import org.scalaide.play2.templateeditor.hyperlink.LocalTemplateHyperlinkComputer
+import org.eclipse.jface.text.ITextHover
 
 class TemplateConfiguration(prefStore: IPreferenceStore, templateEditor: TemplateEditor) extends TextSourceViewerConfiguration with PropertyChangeHandler {
 
@@ -112,15 +113,12 @@ class TemplateConfiguration(prefStore: IPreferenceStore, templateEditor: Templat
     Array(detector, localDetector)
   }
 
-  override def getTextHover(sv: ISourceViewer, contentType: String, stateMask: Int) = {
+  override def getTextHover(sv: ISourceViewer, contentType: String, stateMask: Int): ITextHover = {
     if (contentType.equals(TemplatePartitions.TEMPLATE_SCALA)) {
-      TemplateCompilationUnit.fromEditor(templateEditor) match {
-        case Some(tcu) => new TemplateHover(tcu)
-        case None      => new DefaultTextHover(sv)
-      }
-    } else {
-      new DefaultTextHover(sv)
-    }
+      val cu = TemplateCompilationUnit.fromEditor(templateEditor)
+      new TemplateHover(cu)
+    } 
+    else new DefaultTextHover(sv)
   }
 
   // should be added, because this one is called by default one

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateEditor.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateEditor.scala
@@ -29,9 +29,9 @@ import scala.tools.eclipse.ui.InteractiveCompilationUnitEditor
 import scala.tools.eclipse.InteractiveCompilationUnit
 
 class TemplateEditor extends TextEditor with ISourceViewerEditor with InteractiveCompilationUnitEditor {
-  lazy val preferenceStore = new ChainedPreferenceStore(Array((EditorsUI.getPreferenceStore()), PlayPlugin.prefStore))
-  val sourceViewConfiguration = new TemplateConfiguration(preferenceStore, this)
-  val documentProvider = new TemplateDocumentProvider()
+  private lazy val preferenceStore = new ChainedPreferenceStore(Array((EditorsUI.getPreferenceStore()), PlayPlugin.prefStore))
+  private val sourceViewConfiguration = new TemplateConfiguration(preferenceStore, this)
+  private val documentProvider = new TemplateDocumentProvider()
   
   setSourceViewerConfiguration(sourceViewConfiguration);
   setPreferenceStore(preferenceStore)
@@ -56,8 +56,7 @@ class TemplateEditor extends TextEditor with ISourceViewerEditor with Interactiv
     sourceViewConfiguration.strategy.reconcile(null)
   }
   
-  def getViewer: ISourceViewer = getSourceViewer
+  override def getViewer: ISourceViewer = getSourceViewer
   
-  override def getInteractiveCompilationUnit(): Option[InteractiveCompilationUnit] = TemplateCompilationUnit.fromEditor(this)
-
+  override def getInteractiveCompilationUnit(): InteractiveCompilationUnit = TemplateCompilationUnit.fromEditor(this)
 }

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/reconciler/TemplateReconcilingStrategy.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/reconciler/TemplateReconcilingStrategy.scala
@@ -26,7 +26,7 @@ class TemplateReconcilingStrategy(textEditor: /*ITextEditor*/ TemplateEditor) ex
   private var document: IDocument = _
   private lazy val annotationModel = textEditor.getDocumentProvider.getAnnotationModel(textEditor.getEditorInput)
 
-  lazy val templateUnit = TemplateCompilationUnit.fromEditor(textEditor).get // we know the editor is a Template editor
+  private lazy val templateUnit = TemplateCompilationUnit.fromEditor(textEditor)
 
   def setDocument(doc: IDocument) {
     document = doc

--- a/org.scala-ide.play2/src/org/scalaide/play2/wizards/NewTemplateWizardPage.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/wizards/NewTemplateWizardPage.scala
@@ -2,12 +2,12 @@ package org.scalaide.play2.wizards
 
 import java.io.ByteArrayInputStream
 import java.io.InputStream
-
 import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.Status
 import org.eclipse.jface.viewers.IStructuredSelection
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.ui.dialogs.WizardNewFileCreationPage
+import org.scalaide.play2.PlayPlugin
 
 /**
  * Wizard page based of the new file creation page from the framework.
@@ -56,14 +56,14 @@ class NewTemplateWizardPage(selection: IStructuredSelection) extends WizardNewFi
   // set the page values
   setTitle("Play Template")
   setDescription("Create a new Play Template")
-  setFileExtension("scala.html")
+  setFileExtension(PlayPlugin.TemplateExtension)
 
   /**
    * Return the name of the object to be created, or empty if not available.
    */
   def objectName = {
     val fileName = getFileName()
-    val extenstionLength = ".scala.html".length()
+    val extenstionLength = ("." + PlayPlugin.TemplateExtension).length()
     if (fileName.length > extenstionLength) {
     	fileName.substring(0, fileName.length() - extenstionLength)
     } else {


### PR DESCRIPTION
review by @dragos, @amirsh, @skyluc 

Fixed compilation failure due to scala-ide/scala-ide@c68b3b7d926324b02fc5826029a9741eb4d2bbc0

In the above mentioned commit, the signature of
`InteractiveCompilationUnitEditor.getInteractiveCompilationUnit` was changed.

The only place where I was not entirely sure the refactoring is safe is in
`TemplateConfiguration.getTextHover` However, I believe the change is ok
because the `TemplateConfiguration` can only be used by a `TemplateEditor`,
hence there is no need to check for the `contentType` (and hence the
conditional expression is useless).
