### PR TITLE
Updated build to use latest stable Scala IDE 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ based on Tycho, enabling command line builds.
 There is no default profile. You need to specify a profile manually, choosing what version
 of the Scala IDE and Scala compiler you want to build against:
 
-* `scala-ide-milestone-indigo-scala-2.9`
-* `scala-ide-milestone-juno-scala-2.9`
-* `scala-ide-milestone-indigo-scala-2.10`
-* `scala-ide-milestone-juno-scala-2.10`
+* `scala-ide-3.0-indigo-scala-2.9`
+* `scala-ide-3.0-juno-scala-2.9`
+* `scala-ide-3.0-indigo-scala-2.10`
+* `scala-ide-3.0-juno-scala-2.10`
 
 Run maven like this:
 
-    mvn -P scala-ide-milestone-juno-scala-2.10 clean install
+    mvn -P scala-ide-3.0-juno-scala-2.10 clean install

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-mvn -P scala-ide-milestone-juno-scala-2.10 clean install
+mvn -P scala-ide-3.0-juno-scala-2.10 clean install

--- a/org.scala-ide.play2/META-INF/MANIFEST.MF
+++ b/org.scala-ide.play2/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle:
  org.eclipse.ui.ide,
  org.scala-ide.scala.library,
  org.scala-ide.scala.compiler,
- org.scala-ide.sdt.core;bundle-version="[2.1.0,2.2.0)",
+ org.scala-ide.sdt.core;bundle-version="[3.0.0,3.1.0)",
  org.eclipse.core.resources,
  scalariform,
  org.eclipse.core.filesystem

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <scala.version.short>2.9</scala.version.short>
     <version.tag>local</version.tag>
     <weaving.hook.plugin.version>1.0.200.I20120427-0800</weaving.hook.plugin.version>
-    <repo.scala-ide>${repo.scala-ide.root}/sdk/e37/scala29/dev/site</repo.scala-ide>
+    <repo.scala-ide>${repo.scala-ide.root}/sdk/e37/scala29/stable/site</repo.scala-ide>
     <junit.version>4.10</junit.version>
     <play.artifactId>play_2.9.2</play.artifactId>
     <play.version>2.1-09142012</play.version>
@@ -69,22 +69,22 @@
       <!-- this is the default profile, for the latest Scala IDE build -->
       <!-- it is using the default values for the properties -->
       <!-- latest Scala IDE build, Eclipse Indigo, Scala 2.9 -->
-      <id>scala-ide-milestone-indigo-scala-2.9</id>
+      <id>scala-ide-3.0-indigo-scala-2.9</id>
     </profile>
     <profile>
       <!-- latest Scala IDE build, Eclipse Juno, Scala 2.9 -->
-      <id>scala-ide-milestone-juno-scala-2.9</id>
+      <id>scala-ide-3.0-juno-scala-2.9</id>
       <properties>
         <eclipse.codename>juno</eclipse.codename>
         <repo.eclipse>${repo.eclipse.juno}</repo.eclipse>
         <repo.ajdt>${repo.ajdt.juno}</repo.ajdt>
         <weaving.hook.plugin.version>1.0.200.v20120524-1707</weaving.hook.plugin.version>
-        <repo.scala-ide>${repo.scala-ide.root}/sdk/e38/scala29/dev/site</repo.scala-ide>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/e38/scala29/stable/site</repo.scala-ide>
       </properties>
     </profile>
     <profile>
       <!-- latest Scala IDE build, Eclipse Indigo, Scala 2.10 -->
-      <id>scala-ide-milestone-indigo-scala-2.10</id>
+      <id>scala-ide-3.0-indigo-scala-2.10</id>
       <properties>
         <eclipse.codename>juno</eclipse.codename>
         <repo.eclipse>${repo.eclipse.indigo}</repo.eclipse>
@@ -92,7 +92,7 @@
         <scala.version>2.10.0</scala.version>
         <version.suffix>2_10</version.suffix>
         <scala.version.short>2.10</scala.version.short>
-        <repo.scala-ide>${repo.scala-ide.root}/sdk/e37/scala210/dev/site</repo.scala-ide>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/e37/scala210/stable/site</repo.scala-ide>
         <play.artifactId>play_2.10</play.artifactId>
         <play.version>2.1.0</play.version>
         <templates.artifactId>templates_2.10</templates.artifactId>
@@ -108,7 +108,7 @@
     </profile>
     <profile>
       <!-- latest Scala IDE build, Eclipse Juno, Scala 2.10 -->
-      <id>scala-ide-milestone-juno-scala-2.10</id>
+      <id>scala-ide-3.0-juno-scala-2.10</id>
       <properties>
         <eclipse.codename>juno</eclipse.codename>
         <repo.eclipse>${repo.eclipse.juno}</repo.eclipse>
@@ -117,7 +117,7 @@
         <version.suffix>2_10</version.suffix>
         <scala.version.short>2.10</scala.version.short>
         <weaving.hook.plugin.version>1.0.200.v20120524-1707</weaving.hook.plugin.version>
-        <repo.scala-ide>${repo.scala-ide.root}/sdk/e38/scala210/dev/site</repo.scala-ide>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/e38/scala210/stable/site</repo.scala-ide>
         <play.artifactId>play_2.10</play.artifactId>
         <play.version>2.1.0</play.version>
         <templates.artifactId>templates_2.10</templates.artifactId>


### PR DESCRIPTION
The scala version still is 2.10, updating to 2.10.1 will require a revision of each dependency been compiled with 2.10.1 and updated in maven repos.
