### PR TITLE
Don't restrict where templates can be located..

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/PlayPlugin.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/PlayPlugin.scala
@@ -5,6 +5,7 @@ import org.eclipse.core.resources.IProject
 import org.eclipse.ui.plugin.AbstractUIPlugin
 import org.osgi.framework.BundleContext
 import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.core.runtime.Status
 
 object PlayPlugin {
   @volatile var plugin: PlayPlugin = _
@@ -17,6 +18,10 @@ object PlayPlugin {
 
   def getImageDescriptor(path: String) = {
     AbstractUIPlugin.imageDescriptorFromPlugin(PluginId, path);
+  }
+
+  def log(status: Int, msg: String, ex: Throwable = null) {
+    plugin.getLog.log(new Status(status, plugin.getBundle().getSymbolicName(), msg, ex))
   }
 }
 
@@ -45,5 +50,4 @@ class PlayPlugin extends AbstractUIPlugin {
       playProject <- asPlayProject(iProject)
     } playProject.initialize()
   }
-
 }

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/compiler/CompilerUsing.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/compiler/CompilerUsing.scala
@@ -1,24 +1,20 @@
 package org.scalaide.play2.templateeditor.compiler
 
 import java.io.File
-
 import scala.util.Failure
 import scala.util.Try
-
 import org.scalaide.play2.PlayProject
-
 import play.templates.GeneratedSourceVirtual
-
 import play.templates.ScalaTemplateCompiler
 import play.templates.ScalaTemplateCompiler._
 import play.templates.TemplateCompilationError
 import scalax.file.Path
-
+import scala.tools.eclipse.logging.HasLogger
 
 /**
  * a helper for using template compiler
  */
-object CompilerUsing {
+object CompilerUsing extends HasLogger {
   val templateCompiler = ScalaTemplateCompiler
   val additionalImports = """import play.templates._
 import play.templates.TemplateMagic._
@@ -40,7 +36,7 @@ import views.html._"""
   def compileTemplateToScalaVirtual(content: String, source: File, playProject: PlayProject): Try[GeneratedSourceVirtual] = {
     val sourcePath = playProject.sourceDir.getAbsolutePath()
     if (source.getAbsolutePath().indexOf(sourcePath) == -1)
-      throw new Exception("Template files must locate in '" + sourcePath + "' or its subfolders!")
+      logger.debug(s"Template file '${source.getAbsolutePath}' must be located in '$sourcePath' or one of its subfolders!")
 
     Try {
       templateCompiler.compileVirtual(content, source, playProject.sourceDir, "play.api.templates.Html", "play.api.templates.HtmlFormat", additionalImports)


### PR DESCRIPTION
.. but log a warning in the Error Log (in case this proves a bad idea).

Fixed #45.
