### PR TITLE
Added SYMBOL and NUMBER_LITERAL to Template Syntax Classes

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateSyntaxClasses.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateSyntaxClasses.scala
@@ -16,7 +16,9 @@ object TemplateSyntaxClasses {
     ScalaSyntaxClasses.DEFAULT,
     ScalaSyntaxClasses.OPERATOR,
     ScalaSyntaxClasses.BRACKET,
-    ScalaSyntaxClasses.RETURN))
+    ScalaSyntaxClasses.RETURN,
+    ScalaSyntaxClasses.SYMBOL,
+    ScalaSyntaxClasses.NUMBER_LITERAL))
 
   val htmlCategory = Category("HTML", List(ScalaSyntaxClasses.XML_COMMENT, 
     ScalaSyntaxClasses.XML_ATTRIBUTE_VALUE, 


### PR DESCRIPTION
Numbers and Symbols are always black in the template editor. This should add them to the list in order to change them to fit user prefs.
