### PR TITLE
Reviewed name and description in feature projects

### DIFF
--- a/org.scala-ide.play2.feature/feature.xml
+++ b/org.scala-ide.play2.feature/feature.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.scala-ide.play2.feature"
-      label="Play 2 support in Scala IDE"
+      label="Play2 support in Scala IDE"
       version="0.1.0.qualifier"
       provider-name="Scala IDE"
       plugin="org.scala-ide.play2">
 
-   <description url="http://github.com/scala-ide/scala-ide-play2/wiki/Documentation">
-      Play 2 support in Scala IDE
+   <description url="http://github.com/scala-ide/scala-ide-play2/wiki">
+      Play2 support in Scala IDE
    </description>
 
    <copyright>
@@ -219,7 +219,7 @@
    </license>
 
    <url>
-      <update label="Play 2 support in Scala IDE update site" url="http://example.org/update/site"/>
+      <update label="Play2 support in Scala IDE update site" url="http://example.org/update/site"/>
    </url>
 
    <requires>

--- a/org.scala-ide.play2.source.feature/feature.xml
+++ b/org.scala-ide.play2.source.feature/feature.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
   id="org.scala-ide.play2.source.feature"
-  label="Play 2 support in Scala IDE sources"
+  label="Play2 support in Scala IDE sources"
   version="0.1.0.qualifier"
   provider-name="Scala IDE">
 
-  <description url="http://github.com/scala-ide/scala-ide-play2/wiki/Documentation">
-     The source of Play 2 support in Scala IDE
+  <description url="http://github.com/scala-ide/scala-ide-play2/wiki">
+     The source of Play2 support in Scala IDE
   </description>
 
    <copyright>
@@ -218,7 +218,7 @@
   </license>
 
   <url>
-    <update label="Play 2 support in Scala IDE update site" url="http://example.org/update/site"/>
+    <update label="Play2 support in Scala IDE update site" url="http://example.org/update/site"/>
   </url>
 
   <plugin

--- a/org.scala-ide.play2/src/play/templates/ScalaTemplateCompiler.scala
+++ b/org.scala-ide.play2/src/play/templates/ScalaTemplateCompiler.scala
@@ -1,5 +1,16 @@
 import scala.util.parsing.input.OffsetPosition
 
+/** 
+ *  This source was copied from Play20 codebase
+ *  (@see https://github.com/playframework/Play20/blob/master/framework/src/templates-compiler/src/main/scala/play/templates/ScalaTemplateCompiler.scala).
+ *   
+ *  While the current implementation is identical to the original source, this might change in the future. 
+ *  Please, have a look at the git history of this file to know the exact set of changes.
+ *  
+ *  @note Please, make sure to update the above notice the moment sensible changes are made to this source, as this is required by the section 
+ *        4.2.b of the Apache2 license (Play2 is licensed under Apache2). 
+ *        Specifically, 4.2.b in the Apache2 license states: '''You must cause any modified files to carry prominent notices stating that You changed the files'''.
+ */
 package play.templates {
 
   import scalax.file._


### PR DESCRIPTION
- Updated URL to documentation.
- Changed the feature name from `Play 2` to `Play2`.
- Added notice in `ScalaCompilerTemplate` source.

Fix #60
