### PR TITLE
Fixed build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn -Peclipse-juno -Pscala-2.10.x -Pscala-ide-dev clean package
+mvn -Peclipse-indigo -Pscala-ide-stable clean package


### PR DESCRIPTION
For more information on why we default to use the `eclipse-indigo` and
`scala-ide-stable`, please read  the commit message in SHA:
87f4784c2eff856ee92f1450db656cf6419fda9f.
