### PR TITLE
Add a simple, yet effective auto-indent strategy for template files.

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/TemplateTestSuite.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/TemplateTestSuite.scala
@@ -7,9 +7,10 @@ import org.junit.Assert._
 import org.junit.runners.Suite.SuiteClasses
 import org.scalaide.play2.templateeditor.lexical.TemplatePartitionTokeniserTest
 import org.scalaide.play2.templateeditor.lexical.TemplateCompilationUnitTest
-
+import org.scalaide.play2.indenter.TemplateAutoIndentTest
 @RunWith(value = classOf[org.junit.runners.Suite])
 @SuiteClasses(value = Array(
+  classOf[TemplateAutoIndentTest],
   classOf[TemplatePartitionTokeniserTest],
   classOf[TemplateCompilationUnitTest]))
 class TemplateTestSuite {

--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/indenter/TemplateAutoIndentTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/indenter/TemplateAutoIndentTest.scala
@@ -1,0 +1,144 @@
+package org.scalaide.play2.indenter
+
+import org.eclipse.jface.text.IDocument
+import org.eclipse.jface.text.Document
+import org.eclipse.jface.text.DocumentCommand
+import org.junit.Assert._
+import org.scalaide.play2.templateeditor.TemplateAutoIndentStrategy
+import org.junit.ComparisonFailure
+import org.junit.Test
+
+import org.eclipse.jface.text.DocumentCommand
+
+object TemplateAutoIndentTest {
+  class TestCommand(cOffset: Int, cLength: Int, cText: String, cCaretOffset: Int, cShiftsCaret: Boolean, cDoIt: Boolean) extends DocumentCommand {
+    caretOffset = cCaretOffset
+    doit = cDoIt
+    length = cLength
+    offset = cOffset
+    text = cText
+    shiftsCaret = cShiftsCaret
+  }
+
+}
+
+class TemplateAutoIndentTest {
+  import TemplateAutoIndentTest._
+
+  /** Tests if the input string is equal to the expected output, and the
+   *  output caret position is correct.
+   *
+   *  The '^' character denotes the caret position, both for input and
+   *  expected output.
+   */
+  def test(input: String, expectedOutput: String) {
+    require(input.count(_ == '^') == 1, "the cursor in the input isn't set correctly")
+    require(expectedOutput.count(_ == '^') == 1, "the cursor in the expected output isn't set correctly")
+
+    def createDocument(input: String): IDocument = {
+      val rawInput = input.filterNot(_ == '^')
+      new Document(rawInput)
+    }
+
+    def createTestCommand(input: String): TestCommand = {
+      val pos = input.indexOf('^')
+      new TestCommand(pos, 0, "\n", -1, false, true)
+    }
+
+    val doc = createDocument(input)
+    val cmd = createTestCommand(input)
+    val strategy = new TemplateAutoIndentStrategy(2, useSpacesForTabs = true, "\n")
+
+    strategy.customizeDocumentCommand(doc, cmd)
+
+    import collection.JavaConverters._
+    for (e <- cmd.getCommandIterator().asScala.toList.reverse) {
+      val m = e.getClass().getMethod("execute", classOf[IDocument])
+      m.setAccessible(true)
+      m.invoke(e, doc)
+    }
+
+    val expected = expectedOutput.replaceAll("\\^", "")
+    val actual = doc.get()
+
+    if (expected != actual) {
+      throw new ComparisonFailure("", expected, actual)
+    }
+
+    assertEquals("Caret position is wrong", cmd.caretOffset, expectedOutput.indexOf('^'))
+  }
+
+  @Test
+  def indentPrevLine() {
+    test(
+      """
+  foo^""",
+      """
+  foo
+  ^""")
+  }
+
+  @Test
+  def indentAfterBrace() {
+    test(
+      """
+  foo {^""",
+      """
+  foo {
+    ^""")
+  }
+
+  @Test
+  def indentAfterParen() {
+    test(
+      """
+  foo (^""",
+      """
+  foo (
+    ^""")
+  }
+
+  @Test
+  def indentAfterBraceWithTail() {
+    test(
+      """
+  foo { x => ^""",
+      """
+  foo { x => 
+    ^""")
+  }
+
+  @Test
+  def indentBetweenBraces() {
+    test(
+      """
+  foo {^}""",
+      """
+  foo {
+    ^
+  }""")
+  }
+
+  @Test
+  def indentBetweenBracesWithTail() {
+    test(
+      """
+  foo { x => ^}""",
+      """
+  foo { x => 
+    ^
+  }""")
+  }
+
+  @Test
+  def indentBalancedParens() {
+    test(
+      """
+  foo { x => x + 1 }^
+""",
+      """
+  foo { x => x + 1 }
+  ^
+""")
+  }
+}

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateAutoIndentStrategy.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateAutoIndentStrategy.scala
@@ -1,0 +1,90 @@
+package org.scalaide.play2.templateeditor
+
+import org.eclipse.jface.text.DefaultIndentLineAutoEditStrategy
+import scala.tools.eclipse.logging.HasLogger
+import org.eclipse.jface.text.IDocument
+import org.eclipse.jface.text.DocumentCommand
+import org.eclipse.jface.text.TextUtilities
+import org.eclipse.jface.text.source.SourceViewerConfiguration
+import org.eclipse.jface.text.source.ISourceViewer
+import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.core.runtime.Platform
+
+/** Simple auto-indent strategy.
+ *
+ *  - By default, indent to the previous line.
+ *  - If the line contains unbalanced (open) parenthesis to the left of the caret, indent further by 1 tab width
+ *  - If the rest of the line (to the right of caret) starts with a closed parenthesis, add a new line and indent
+ *    the closing parenthesis to the previous line (without moving the caret)
+ *
+ *  @note This class does not distinguish between `(' and `{', so a line like `(blah}` is considered balanced
+ */
+class TemplateAutoIndentStrategy(tabSize: Int, useSpacesForTabs: Boolean, defaultLineSeparator: String) extends DefaultIndentLineAutoEditStrategy with HasLogger {
+  private final val INDENT = if (useSpacesForTabs) " " * tabSize else "\t"
+  private final val openParens = Set('(', '{')
+  private final val closedParens = Set(')', '}')
+
+  override def customizeDocumentCommand(doc: IDocument, cmd: DocumentCommand) {
+    if (cmd.offset == -1 || doc.getLength() == 0) return // don't spend time on invalid docs
+
+    try {
+      if (cmd.length == 0 && cmd.text != null && TextUtilities.endsWith(doc.getLegalLineDelimiters(), cmd.text) != -1) {
+        autoIndent(doc, cmd)
+      }
+    } catch {
+      case e: Exception =>
+        // don't break typing under any circumstances
+        eclipseLog.warn("Error in scaladoc autoedit", e)
+    }
+  }
+
+  private def autoIndent(doc: IDocument, cmd: DocumentCommand) {
+    val LineInfo(indent, prefix, tail) = breakLine(doc, cmd.offset)
+    val newLine = Option(doc.getLineDelimiter(0)).getOrElse(defaultLineSeparator)
+
+    val buf = new StringBuilder(cmd.text)
+
+    buf.append(indent)
+    if (unbalancedOpenParens(prefix)) {
+      buf.append(INDENT)
+    }
+
+    val caretOffset = cmd.offset + buf.length
+    if ((tail.length() > 0) && closedParens(tail.charAt(0)))
+      buf.append(newLine).append(indent)
+
+    cmd.text = buf.toString
+    cmd.caretOffset = caretOffset
+    cmd.shiftsCaret = false
+  }
+
+  /** Are there unbalanced parenthesis/braces in this string? */
+  private def unbalancedOpenParens(line: String): Boolean = {
+    var open = 0
+    for (ch <- line)
+      if (openParens(ch))
+        open += 1
+      else if (closedParens(ch))
+        open -= 1
+
+    open > 0
+  }
+
+  /** Return information about the line at given offset */
+  private def breakLine(doc: IDocument, offset: Int): LineInfo = {
+    val lineInfo = doc.getLineInformationOfOffset(offset)
+    val endOfWS = findEndOfWhiteSpace(doc, lineInfo.getOffset(), offset)
+    val indent = doc.get(lineInfo.getOffset, endOfWS - lineInfo.getOffset)
+    val prefix = doc.get(endOfWS, offset - endOfWS)
+    val restAfterCaret = doc.get(offset, lineInfo.getOffset() - offset + lineInfo.getLength())
+    LineInfo(indent, prefix, restAfterCaret)
+  }
+}
+
+/** Line information
+ *
+ *  @param indent whitespace-only prefix
+ *  @param prefix characters between `indent` and the caret
+ *  @param tail   characters between the caret and the end of the line
+ */
+private case class LineInfo(indent: String, prefix: String, tail: String)

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplatePartitions.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplatePartitions.scala
@@ -12,7 +12,7 @@ object TemplatePartitions {
   val TEMPLATE_TAG = "__template_tag"
 
   def getTypes() = {
-    Array(TEMPLATE_DEFAULT, TEMPLATE_SCALA, TEMPLATE_COMMENT, TEMPLATE_TAG);
+    Array(TEMPLATE_DEFAULT, TEMPLATE_SCALA, TEMPLATE_COMMENT, TEMPLATE_TAG, TEMPLATE_PLAIN);
   }
 
 }


### PR DESCRIPTION
This can be obviously improved, but the current behavior seems to match well
what programmers expect. See comments in TemplateAutoIndentStrategy.scala for
specification.

Fixed #57.
