### PR TITLE
Fix issue related to template imports preferences with %format% feature from Play2

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/compiler/CompilerUsing.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/compiler/CompilerUsing.scala
@@ -34,8 +34,11 @@ import views.html._
     if (source.getAbsolutePath().indexOf(sourcePath) == -1)
       logger.debug(s"Template file '${source.getAbsolutePath}' must be located in '$sourcePath' or one of its subfolders!")
 
+    val extension = source.getName.split('.').last
+
     Try {
-      templateCompiler.compileVirtual(content, source, playProject.sourceDir, "play.api.templates.Html", "play.api.templates.HtmlFormat", additionalImports + playProject.cachedPreferenceStore.getString(PlayPreferences.TemplateImports))
+      val templateImports = additionalImports + playProject.cachedPreferenceStore.getString(PlayPreferences.TemplateImports).replace("%format%", extension);
+      templateCompiler.compileVirtual(content, source, playProject.sourceDir, "play.api.templates.Html", "play.api.templates.HtmlFormat", templateImports);
     } recoverWith {
       case TemplateCompilationError(source, message, line, column) =>
         val offset = PositionHelper.convertLineColumnToOffset(content, line, column)


### PR DESCRIPTION
In Play2 you can specify additional imports like this views.%format%, the string '%format%' is replaced with the file extension during the template source code creation.

https://github.com/playframework/Play20/blob/master/framework/src/sbt-plugin/src/main/scala/PlayCommands.scala#L318
