### PR TITLE
Improved code completion based on discussion of issue #49.

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateConfiguration.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateConfiguration.scala
@@ -74,6 +74,7 @@ class TemplateConfiguration(prefStore: IPreferenceStore, templateEditor: Templat
     assistant.setDocumentPartitioning(getConfiguredDocumentPartitioning(sourceViewer))
     assistant.setContentAssistProcessor(new CompletionProposalComputer(templateEditor), TemplatePartitions.TEMPLATE_SCALA)
     assistant.setContentAssistProcessor(new CompletionProposalComputer(templateEditor), TemplatePartitions.TEMPLATE_PLAIN)
+    assistant.setContentAssistProcessor(new CompletionProposalComputer(templateEditor), TemplatePartitions.TEMPLATE_TAG)
     assistant.setContentAssistProcessor(new CompletionProposalComputer(templateEditor), IDocument.DEFAULT_CONTENT_TYPE)
     assistant
   }


### PR DESCRIPTION
I see this little improvement like a starting to point to allow a better final solution to the issue #49.

The main problem is that Play2 define a special syntax in which a final dot is associated to the html template part like a "floating one". This particular commit is a hack that allow bundling the dot with simple expressions (no chaining methods for now).

A major problem is that since the parsing is the same for code completions and errors indicators, for each hack of this type in template the compiler it's necessary the reverse in the presentation compiler.

For some reason the Ctrl+Space is a little tricky when the cursor is close to an angle bracket and that's the reason I added TEMPLATE_TAG to the assist processor.

![Screen Shot 2013-04-27 at 1 07 21 AM](https://f.cloud.github.com/assets/143813/433846/7dfe3fea-aef8-11e2-8a07-57108e9e4a35.png)

![Screen Shot 2013-04-27 at 1 07 32 AM](https://f.cloud.github.com/assets/143813/433848/8c112430-aef8-11e2-93e0-3518a94af495.png)
