### PR TITLE
Align the editor bundle version with the rest of the plugin.

### DIFF
--- a/org.scala-ide.sdt.editor.tests/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.editor.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Editor Tests
 Bundle-SymbolicName: org.scala-ide.sdt.editor.tests
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Vendor:  scala-ide.org
 Fragment-Host: org.scala-ide.sdt.editor
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/org.scala-ide.sdt.editor.tests/pom.xml
+++ b/org.scala-ide.sdt.editor.tests/pom.xml
@@ -7,7 +7,6 @@
   </parent>
   <artifactId>org.scala-ide.sdt.editor.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>0.1.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>

--- a/org.scala-ide.sdt.editor/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.editor/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name:  %pluginName
 Bundle-SymbolicName: org.scala-ide.sdt.editor
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 0.2.0.qualifier
 Bundle-Vendor:  %providerName
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/org.scala-ide.sdt.editor/pom.xml
+++ b/org.scala-ide.sdt.editor/pom.xml
@@ -8,6 +8,5 @@
     <version>0.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.scala-ide.sdt.editor</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
This makes it easier to manage releases and version bumps.
