### PR TITLE
Only show URI completion when the prefix matches

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/UriCompletionComputerTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/UriCompletionComputerTest.scala
@@ -136,17 +136,30 @@ class UriCompletionComputerTest extends CompletionComputerTest {
 
     route expectedCompletions Seq("/foo", "/foo/bar")
   }
-  
+
   @Test
-  def completion_should_suggest_all_alternative_uri_if_no_specific_match_can_be_found() {
+  def completion_should_suggest_only_prefix_matching_completions() {
     val route = RouteFile {
       """
         |GET /foo
+        |GET /published
         |GET /pub@lic
         |GET /buz
       """
     }
 
-    route expectedCompletions Seq("/buz", "/foo")
+    route expectedCompletions Seq("/public", "/published")
+  }
+
+  @Test
+  def completion_should_suggest_nothing_if_nothing_matches() {
+    val route = RouteFile {
+      """
+        |GET /foo
+        |GET /buz/:id@
+      """
+    }
+
+    route expectedCompletions Seq()
   }
 }

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/UriCompletionComputer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/UriCompletionComputer.scala
@@ -33,7 +33,8 @@ class UriCompletionComputer extends IContentAssistProcessor {
     val document = viewer.getDocument()
 
     val word = wordFinder.findWord(document, offset)
-    val rawUri = document.get(word.getOffset, word.getLength)
+    // only consider the prefix (word to the left of caret)
+    val rawUri = document.get(word.getOffset, (offset - word.getOffset()))
     val uri = RouteUri(rawUri)
 
     val existingUris = existingUrisInDocument(document) - uri
@@ -55,9 +56,7 @@ class UriCompletionComputer extends IContentAssistProcessor {
  
     val allUrisProposals = defaultUriProposal ++ staticUrisProposals ++ dynamicUrisProposals
 
-    // If `offset` is in the middle of a URI part, it is possible that the set of `allUrisProposals` is empty. If that happens, returns the set of `existingUris`
-    val finalProposals = if (allUrisProposals.isEmpty) existingUris else allUrisProposals
-    val sortedProposals = finalProposals.toList.sorted(RouteUri.AlphabeticOrder)
+    val sortedProposals = allUrisProposals.toList.sorted(RouteUri.AlphabeticOrder)
     
     sortedProposals.map(new UriCompletionProposal(word, _)).toArray
   }


### PR DESCRIPTION
This fixes questionable behavior when the user wrote code and presses enter to
hide the completion box, but that instead replaces his own code.

Fixed #107.
