### PR TITLE
Show quick assists when the caret is inside a Scala method.

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/quickassist/ResolverTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/quickassist/ResolverTest.scala
@@ -73,7 +73,9 @@ class ResolverTest {
   private val scalaResolvedMethods = Set(
     ControllerMethod("controllers.Application.index", List()),
     ControllerMethod("controllers.Application.post", List(("id", "Long"))),
-    ControllerMethod("controllers.Application.postText", List(("text", "String"), ("id", "Int"))))
+    ControllerMethod("controllers.Application.postText", List(("text", "String"), ("id", "Int"))),
+    ControllerMethod("controllers.Application.internalPostText1", List(("text", "String"), ("id", "Char"))),
+    ControllerMethod("controllers.Application.internalPostText2", List(("text", "String"), ("id", "Short"))))
 
   private val javaResolvedMethods = Set(
     ControllerMethod("controllers.JavaApplication.index", List()),

--- a/org.scala-ide.play2.tests/test-workspace/resolver/app/controllers/Application.scala
+++ b/org.scala-ide.play2.tests/test-workspace/resolver/app/controllers/Application.scala
@@ -12,4 +12,11 @@ object Application {
 
   def/*!*/ postText(text: String, id: Int) = Action {
   }
+
+  def internalPostText1(text: String, /*!*/id: Char) = Action {
+  }
+
+  def internalPostText2(text: String, id: Short) = Action {
+    /*!*/
+  }
 }

--- a/org.scala-ide.sdt.editor/src/org/scalaide/editor/PresentationCompilerExtensions.scala
+++ b/org.scala-ide.sdt.editor/src/org/scalaide/editor/PresentationCompilerExtensions.scala
@@ -1,0 +1,29 @@
+package org.scalaide.editor
+
+import scala.tools.eclipse.ScalaPresentationCompiler
+import scala.reflect.internal.util.SourceFile
+
+/** A few convenience methods on top of the presentation compiler
+ *
+ *  This should migrate to sdt.core/interactive compiler as needed.
+ */
+abstract class PresentationCompilerExtensions {
+  val compiler: ScalaPresentationCompiler
+
+  import compiler._
+
+  /** Locate smallest tree that encloses position.
+   *
+   *  Returns `EmptyTree` if the position could not be found.
+   */
+  def locateIn(tree: Tree, pos: Position, p: Tree => Boolean = t => true): Tree =
+    new FilteringLocator(pos, p) locateIn tree
+
+  class FilteringLocator(pos: Position, p: Tree => Boolean) extends Locator(pos) {
+    override def isEligible(t: Tree) = super.isEligible(t) && p(t)
+  }
+
+  def getEnclosingMethd(src: SourceFile, offset: Int) = {
+    locateIn(parseTree(src), rangePos(src, offset, offset, offset), t => t.isInstanceOf[DefDef])
+  }
+}


### PR DESCRIPTION
Fixed #109.
