### PR TITLE
Fixed action hyperlinking in route files when route definition starts wi...

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/hyperlink/RouteHyperlinkDetectorTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/hyperlink/RouteHyperlinkDetectorTest.scala
@@ -44,156 +44,226 @@ class RouteHyperlinkDetectorTest extends RouteTest {
 
   @Test
   def scalaControllerNoParameterAction() {
-    testWithAnswer("""GET     /   controllers.ScalaA@pplication.intro""", "controllers.ScalaApplication.intro")
+    testWithAnswer("""GET     /   controllers.ScalaA~pplication.intro""", "controllers.ScalaApplication.intro")
   }
 
   @Test
   def scalaControllerNoParameterAction2() {
-    testWithAnswer("""GET     /   controllers.ScalaApplication@.withEmptyParams""", "controllers.ScalaApplication.withEmptyParams()")
+    testWithAnswer("""GET     /   controllers.ScalaApplication~.withEmptyParams""", "controllers.ScalaApplication.withEmptyParams()")
   }
 
   @Test
   def scalaControllerEmptyParametersAction() {
-    testWithAnswer("""GET     /   controllers.ScalaA@pplication.intro()""", "controllers.ScalaApplication.intro")
+    testWithAnswer("""GET     /   controllers.ScalaA~pplication.intro()""", "controllers.ScalaApplication.intro")
   }
 
   @Test
   def scalaControllerEmptyParametersAction2() {
-    testWithAnswer("""GET     /   controllers.ScalaApplication@.withEmptyParams()""", "controllers.ScalaApplication.withEmptyParams()")
+    testWithAnswer("""GET     /   controllers.ScalaApplication~.withEmptyParams()""", "controllers.ScalaApplication.withEmptyParams()")
   }
 
   @Test
   def scalaControllerIntAction() {
-    testWithAnswer("""GET     /:a   controllers.ScalaApplicati@on.pInt(a: Int)""", "controllers.ScalaApplication.pInt(Int)")
+    testWithAnswer("""GET     /:a   controllers.ScalaApplicati~on.pInt(a: Int)""", "controllers.ScalaApplication.pInt(Int)")
   }
 
   @Test
   def scalaControllerStringAction() {
-    testWithAnswer("""GET     /:a   controllers.ScalaApplicatio@n.pString(a)""", "controllers.ScalaApplication.pString(String)")
+    testWithAnswer("""GET     /:a   controllers.ScalaApplicatio~n.pString(a)""", "controllers.ScalaApplication.pString(String)")
   }
 
   @Test
   def scalaControllerRefAction() {
-    testWithAnswer("""GET     /:a   controllers.ScalaApplicatio@n.pRef(a: model.Element)""", "controllers.ScalaApplication.pRef(model.Element)")
+    testWithAnswer("""GET     /:a   controllers.ScalaApplicatio~n.pRef(a: model.Element)""", "controllers.ScalaApplication.pRef(model.Element)")
   }
 
   @Test
   def scalaControllerOverloadedIntAction() {
-    testWithAnswer("""GET     /:a   controllers.ScalaApplicati@on.overloaded(a: Int)""", "controllers.ScalaApplication.overloaded(Int)")
+    testWithAnswer("""GET     /:a   controllers.ScalaApplicati~on.overloaded(a: Int)""", "controllers.ScalaApplication.overloaded(Int)")
   }
 
   @Test
   def scalaControllerOverloadedStringAction() {
-    testWithAnswer("""GET     /:a   controllers.ScalaApplicati@on.overloaded(a)""", "controllers.ScalaApplication.overloaded(String)")
+    testWithAnswer("""GET     /:a   controllers.ScalaApplicati~on.overloaded(a)""", "controllers.ScalaApplication.overloaded(String)")
   }
 
   @Test
   def scalaControllerOverloadedRefAction() {
-    testWithAnswer("""GET     /:a   controllers.ScalaApplicati@on.overloaded(a: model.Element)""", "controllers.ScalaApplication.overloaded(model.Element)")
+    testWithAnswer("""GET     /:a   controllers.ScalaApplicati~on.overloaded(a: model.Element)""", "controllers.ScalaApplication.overloaded(model.Element)")
   }
 
   @Test
   def scalaControllerOverloadedStringRefAction() {
-    testWithAnswer("""GET     /:a   controllers.ScalaApplicati@on.overloaded(b, a: model.Element)""", "controllers.ScalaApplication.overloaded(String,model.Element)")
+    testWithAnswer("""GET     /:a   controllers.ScalaApplicati~on.overloaded(b, a: model.Element)""", "controllers.ScalaApplication.overloaded(String,model.Element)")
   }
 
   @Test
   def scalaNoMatch {
-    testWithoutAnswer("""GET     /   some.unexisting.p@ackage.Application.index""")
+    testWithoutAnswer("""GET     /   some.unexisting.p~ackage.Application.index""")
   }
 
   @Test
   def scalaWrongParameterTypes {
-    testWithoutAnswer("""GET     /:s   controllers.Sca@laApplication.pInt(s)""")
+    testWithoutAnswer("""GET     /:s   controllers.Sca~laApplication.pInt(s)""")
   }
 
   @Test
   def scalaWrongParameterTypesOverloaded {
-    testWithoutAnswer("""GET     /:s   controllers.ScalaAppl@ication.overloaded(s, i: Int)""")
+    testWithoutAnswer("""GET     /:s   controllers.ScalaAppl~ication.overloaded(s, i: Int)""")
+  }
+
+  @Test
+  def scalaControllerClassNoParameterAction() {
+    testWithAnswer("""GET     /   @controllers.ScalaC~lass.intro""", "controllers.ScalaClass.intro")
+  }
+
+  @Test
+  def scalaControllerClassNoParameterAction2() {
+    testWithAnswer("""GET     /   @controllers.ScalaClass~.withEmptyParams""", "controllers.ScalaClass.withEmptyParams()")
+  }
+
+  @Test
+  def scalaControllerClassEmptyParametersAction() {
+    testWithAnswer("""GET     /   @controllers.ScalaC~lass.intro()""", "controllers.ScalaClass.intro")
+  }
+
+  @Test
+  def scalaControllerClassEmptyParametersAction2() {
+    testWithAnswer("""GET     /   @controllers.ScalaClass~.withEmptyParams()""", "controllers.ScalaClass.withEmptyParams()")
+  }
+
+  @Test
+  def scalaControllerClassIntAction() {
+    testWithAnswer("""GET     /:a   @controllers.ScalaCla~ss.pInt(a: Int)""", "controllers.ScalaClass.pInt(Int)")
+  }
+
+  @Test
+  def scalaControllerClassStringAction() {
+    testWithAnswer("""GET     /:a   @controllers.ScalaClas~s.pString(a)""", "controllers.ScalaClass.pString(String)")
+  }
+
+  @Test
+  def scalaControllerClassRefAction() {
+    testWithAnswer("""GET     /:a   @controllers.ScalaClas~s.pRef(a: model.Element)""", "controllers.ScalaClass.pRef(model.Element)")
+  }
+
+  @Test
+  def scalaControllerClassOverloadedIntAction() {
+    testWithAnswer("""GET     /:a   @controllers.ScalaCla~ss.overloaded(a: Int)""", "controllers.ScalaClass.overloaded(Int)")
+  }
+
+  @Test
+  def scalaControllerClassOverloadedStringAction() {
+    testWithAnswer("""GET     /:a   @controllers.ScalaCla~ss.overloaded(a)""", "controllers.ScalaClass.overloaded(String)")
+  }
+
+  @Test
+  def scalaControllerClassOverloadedRefAction() {
+    testWithAnswer("""GET     /:a   @controllers.ScalaCla~ss.overloaded(a: model.Element)""", "controllers.ScalaClass.overloaded(model.Element)")
+  }
+
+  @Test
+  def scalaControllerClassOverloadedStringRefAction() {
+    testWithAnswer("""GET     /:a   @controllers.ScalaCla~ss.overloaded(b, a: model.Element)""", "controllers.ScalaClass.overloaded(String,model.Element)")
+  }
+
+  @Test
+  def scalaClassNoMatch {
+    testWithoutAnswer("""GET     /   @some.unexisting.p~ackage.Class.index""")
+  }
+
+  @Test
+  def scalaClassWrongParameterTypes {
+    testWithoutAnswer("""GET     /:s   controllers.Sca~laClass.pInt(s)""")
+  }
+
+  @Test
+  def scalaClassWrongParameterTypesOverloaded {
+    testWithoutAnswer("""GET     /:s   controllers.ScalaCl~ass.overloaded(s, i: Int)""")
   }
 
   @Test
   def javaControllerNoParameterAction() {
-    testWithAnswer("""GET     /   controllers.JavaAp@plication.intro""", "controllers.JavaApplication.intro()QObject;")
+    testWithAnswer("""GET     /   controllers.JavaAp~plication.intro""", "controllers.JavaApplication.intro()QObject;")
   }
 
   @Test
   def javaControllerNoParameterAction2() {
-    testWithAnswer("""GET     /   controllers.JavaAp@plication.withEmptyParams""", "controllers.JavaApplication.withEmptyParams()QObject;")
+    testWithAnswer("""GET     /   controllers.JavaAp~plication.withEmptyParams""", "controllers.JavaApplication.withEmptyParams()QObject;")
   }
 
   @Test
   def javaControllerEmptyParametersAction() {
-    testWithAnswer("""GET     /   controllers.JavaAp@plication.intro()""", "controllers.JavaApplication.intro()QObject;")
+    testWithAnswer("""GET     /   controllers.JavaAp~plication.intro()""", "controllers.JavaApplication.intro()QObject;")
   }
 
   @Test
   def javaControllerEmptyParametersAction2() {
-    testWithAnswer("""GET     /   controllers.JavaApplication.@withEmptyParams()""", "controllers.JavaApplication.withEmptyParams()QObject;")
+    testWithAnswer("""GET     /   controllers.JavaApplication.~withEmptyParams()""", "controllers.JavaApplication.withEmptyParams()QObject;")
   }
 
   @Test
   def javaControllerIntAction() {
-    testWithAnswer("""GET     /:a   controllers.JavaApplicatio@n.pInt(a: Int)""", "controllers.JavaApplication.pInt(I)QObject;")
+    testWithAnswer("""GET     /:a   controllers.JavaApplicatio~n.pInt(a: Int)""", "controllers.JavaApplication.pInt(I)QObject;")
   }
 
   @Test
   def javaControllerStringAction() {
-    testWithAnswer("""GET     /:a   controllers.JavaApplication@.pString(a)""", "controllers.JavaApplication.pString(QString;)QObject;")
+    testWithAnswer("""GET     /:a   controllers.JavaApplication~.pString(a)""", "controllers.JavaApplication.pString(QString;)QObject;")
   }
 
   @Test
   def javaControllerRefAction() {
-    testWithAnswer("""GET     /:a   controllers.JavaApplication@.pRef(a: model.Element)""", "controllers.JavaApplication.pRef(QElement;)QObject;")
+    testWithAnswer("""GET     /:a   controllers.JavaApplication~.pRef(a: model.Element)""", "controllers.JavaApplication.pRef(QElement;)QObject;")
   }
 
   @Test
   def javaControllerOverloadedIntAction() {
-    testWithAnswer("""GET     /:a   controllers.JavaApplicatio@n.overloaded(a: Int)""", "controllers.JavaApplication.overloaded(I)QObject;")
+    testWithAnswer("""GET     /:a   controllers.JavaApplicatio~n.overloaded(a: Int)""", "controllers.JavaApplication.overloaded(I)QObject;")
   }
 
   @Test
   def javaControllerOverloadedStringAction() {
-    testWithAnswer("""GET     /:a   controllers.JavaApplicatio@n.overloaded(a)""", "controllers.JavaApplication.overloaded(QString;)QObject;")
+    testWithAnswer("""GET     /:a   controllers.JavaApplicatio~n.overloaded(a)""", "controllers.JavaApplication.overloaded(QString;)QObject;")
   }
 
   @Test
   def javaControllerOverloadedRefAction() {
-    testWithAnswer("""GET     /:a   controllers.JavaApplicatio@n.overloaded(a: model.Element)""", "controllers.JavaApplication.overloaded(QElement;)QObject;")
+    testWithAnswer("""GET     /:a   controllers.JavaApplicatio~n.overloaded(a: model.Element)""", "controllers.JavaApplication.overloaded(QElement;)QObject;")
   }
 
   @Test
   def javaControllerOverloadedStringRefAction() {
-    testWithAnswer("""GET     /:a   controllers.JavaApplicatio@n.overloaded(b, a: model.Element)""", "controllers.JavaApplication.overloaded(QString;QElement;)QObject;")
+    testWithAnswer("""GET     /:a   controllers.JavaApplicatio~n.overloaded(b, a: model.Element)""", "controllers.JavaApplication.overloaded(QString;QElement;)QObject;")
   }
 
   @Test
   def javaNoMatch {
-    testWithoutAnswer("""GET     /   some.unexisting.p@ackage.Application.index""")
+    testWithoutAnswer("""GET     /   some.unexisting.p~ackage.Application.index""")
   }
 
   @Test
   def javaWrongParameterTypes {
-    testWithoutAnswer("""GET     /:s   some.unexisting@.package.Application.pInt(s)""")
+    testWithoutAnswer("""GET     /:s   some.unexisting~.package.Application.pInt(s)""")
   }
 
   @Test
   def javaWrongParameterTypesOverloaded {
-    testWithoutAnswer("""GET     /:s   some.unexisting.packa@ge.Application.overloaded(s, i: Int)""")
+    testWithoutAnswer("""GET     /:s   some.unexisting.packa~ge.Application.overloaded(s, i: Int)""")
   }
 
   private def testWithAnswer(
     content: String,
     expectedLabel: String) {
 
-    val file = RouteFile(content)
+    val file = RouteFile(content, List('~'))
 
-    val actual = RouteHyperlinkComputer.detectHyperlinks(project, file.document, new Region(file.caretOffset('@'), 0), createJavaHyperlink)
+    val actual = RouteHyperlinkComputer.detectHyperlinks(project, file.document, new Region(file.caretOffset('~'), 0), createJavaHyperlink)
 
     actual match {
       case Some(hyperlink) =>
         assertEquals("Wrong label", expectedLabel, hyperlink.getTypeLabel())
-        assertEquals("Wrong region", file.document.getPartition(file.caretOffset('@')), hyperlink.getHyperlinkRegion())
+        assertEquals("Wrong region", file.document.getPartition(file.caretOffset('~')), hyperlink.getHyperlinkRegion())
       case _ =>
         fail("Wrong detectHyperlink result. Expected: Some(hyperlink), was: %s".format(actual))
     }
@@ -201,9 +271,9 @@ class RouteHyperlinkDetectorTest extends RouteTest {
 
   private def testWithoutAnswer(content: String) {
 
-    val file = RouteFile(content)
+    val file = RouteFile(content, List('~'))
 
-    val actual = RouteHyperlinkComputer.detectHyperlinks(project, file.document, new Region(file.caretOffset('@'), 0), createJavaHyperlink)
+    val actual = RouteHyperlinkComputer.detectHyperlinks(project, file.document, new Region(file.caretOffset('~'), 0), createJavaHyperlink)
 
     actual match {
       case None =>

--- a/org.scala-ide.play2.tests/test-workspace/routeHyperlink/app/controllers/ScalaApplication.scala
+++ b/org.scala-ide.play2.tests/test-workspace/routeHyperlink/app/controllers/ScalaApplication.scala
@@ -22,3 +22,24 @@ object ScalaApplication {
 
   def overloaded(s: String, b: Element): AnyRef = ???
 }
+
+class ScalaClass {
+
+  def intro: AnyRef = ???
+  
+  def withEmptyParams(): AnyRef = ???
+  
+  def pInt(a: Int): AnyRef = ???
+  
+  def pString(a: String): AnyRef = ???
+  
+  def pRef(a: Element): AnyRef = ???
+  
+  def overloaded(b: Int): AnyRef = ???
+  
+  def overloaded(c: String): AnyRef = ???
+  
+  def overloaded(b: Element): AnyRef = ???
+
+  def overloaded(s: String, b: Element): AnyRef = ???
+}

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/RouteAction.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/RouteAction.scala
@@ -9,13 +9,17 @@ object RouteAction {
 
   /** Regex for the an action with parameters.
    *  "package.Object.action(...xxx...)"
+   *  or
+   *  "@package.Class.action(...xxx...)"
    */
-  private final val ActionWithParametersRegex = """([^\(]*)\.([^\.\(]*)\(([^\)]*)\)""".r
+  private final val ActionWithParametersRegex = """@?([^\(]*)\.([^\.\(]*)\(([^\)]*)\)""".r
 
   /** Regex for the an action without parameters.
    *  "package.Object.action"
+   *  or
+   *  "@package.Class.action"
    */
-  private final val ActionWithoutParametersRegex = """([^\(]*)\.([^\.\(]*)""".r
+  private final val ActionWithoutParametersRegex = """@?([^\(]*)\.([^\.\(]*)""".r
 
   /** Regex for the individual parameters.
    *  The support format is: "page: Int ?= 1"

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/hyperlink/RouteHyperlinkComputer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/hyperlink/RouteHyperlinkComputer.scala
@@ -44,7 +44,13 @@ object RouteHyperlinkComputer {
             val obj = rootMirror.getModuleIfDefined(routeAction.typeName)
 
             // method or methods of the object with the given name
-            val method = obj.info.member(newTermName(routeAction.methodName))
+            val objMethod = obj.info.member(newTermName(routeAction.methodName))
+            
+            // if the method of the object doesn't exist, than perhaps routeAction.typeName is actually a class
+            // so let's try getting the class and searching it's methods for routeAction.methodName
+            val method =
+              if (objMethod.exists) objMethod
+              else 					rootMirror.getClassIfDefined(routeAction.typeName).info.member(newTermName(routeAction.methodName))
 
             if (!method.exists) {
               None


### PR DESCRIPTION
...th '@'.

Changed action's regular expressions to account for optional starting '@' character.

When searching for the method, if there does not exist a matching method on a module that matches the route action type name, then do a corresponding search for the method over classes.

Fix #119
