### PR TITLE
Fixes #133 Show completions on controller methods returning an `EssentialAction`

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessorTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessorTest.scala
@@ -83,13 +83,23 @@ class ActionContentAssistProcessorTest extends CompletionComputerTest {
   }
 
   @Test
-  def overloaded_method_completion() {
+  def overloaded_method_completion_on_action() {
     val route = RouteCompletionFile { "GET / controllers.simple.SimpleScalaPlayApp.overloadedActi#" }
 
     route expectedCompletions (Proposal("overloadedAction()", MemberKind.Def),
       Proposal("overloadedAction(id: Long)", MemberKind.Def),
       Proposal("overloadedAction(s)", MemberKind.Def))
   }
+
+  @Test
+  def overloaded_method_completion_on_essential_action() {
+    val route = RouteCompletionFile { "GET / controllers.simple.SimpleScalaPlayApp.overloadedEsse#" }
+
+    route expectedCompletions (Proposal("overloadedEssentialAction()", MemberKind.Def),
+      Proposal("overloadedEssentialAction(id: Long)", MemberKind.Def),
+      Proposal("overloadedEssentialAction(s)", MemberKind.Def))
+  }
+
 
   @Test
   def simple_val_completion_for_scala_controller() {

--- a/org.scala-ide.play2.tests/test-workspace/resolver/src/play/api/mvc/Action.scala
+++ b/org.scala-ide.play2.tests/test-workspace/resolver/src/play/api/mvc/Action.scala
@@ -1,6 +1,6 @@
 package play.api.mvc
 
-class Action
+class Action extends EssentialAction
 
 object Action {
   def apply[A](f: => A) = new Action

--- a/org.scala-ide.play2.tests/test-workspace/resolver/src/play/api/mvc/EssentialAction.scala
+++ b/org.scala-ide.play2.tests/test-workspace/resolver/src/play/api/mvc/EssentialAction.scala
@@ -1,0 +1,7 @@
+package play.api.mvc
+
+class EssentialAction
+
+object EssentialAction {
+  def apply[A](f: => A) = new EssentialAction
+}

--- a/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/app/controllers/simple/SimpleScalaPlayApp.scala
+++ b/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/app/controllers/simple/SimpleScalaPlayApp.scala
@@ -23,4 +23,8 @@ object SimpleScalaPlayApp extends Controller {
   def overloadedAction(s: String) = Action {}
   def overloadedAction(id: Long) = Action {}
   def overloadedAction() = Action {}
+
+  def overloadedEssentialAction(s: String) = EssentialAction {}
+  def overloadedEssentialAction(id: Long) = EssentialAction {}
+  def overloadedEssentialAction() = EssentialAction {}
 }

--- a/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/src/play/api/mvc/Action.scala
+++ b/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/src/play/api/mvc/Action.scala
@@ -1,6 +1,6 @@
 package play.api.mvc
 
-trait Action
+trait Action extends EssentialAction
 
 object Action {
   def apply[A](f: => A) = new Action {}

--- a/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/src/play/api/mvc/EssentialAction.scala
+++ b/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/src/play/api/mvc/EssentialAction.scala
@@ -1,0 +1,7 @@
+package play.api.mvc
+
+trait EssentialAction
+
+object EssentialAction {
+  def apply[A](f: => A) = new EssentialAction {}
+}

--- a/org.scala-ide.play2/src/org/scalaide/play2/PlayClassNames.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/PlayClassNames.scala
@@ -7,7 +7,7 @@ trait PlayClassNames {
 
 object ScalaPlayClassNames {
   final val ControllerClassFullName = "play.api.mvc.Controller"
-  final val ActionClassFullName = "play.api.mvc.Action"
+  final val ActionClassFullName = "play.api.mvc.EssentialAction"
 }
 
 trait ScalaPlayClassNames extends PlayClassNames {

--- a/org.scala-ide.play2/src/org/scalaide/play2/quickassist/ControllerMethodResolver.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/quickassist/ControllerMethodResolver.scala
@@ -25,7 +25,7 @@ import org.scalaide.play2.JavaPlayClassNames
 trait ControllerMethodResolver extends PlayClassNames {
 
   /** Return an instance of `ControllerMethod`, if the offset points to a Play controller method.
-   *  A Play controller method is any method that returns an instance of `Action`
+   *  A Play controller method is any method that returns an instance of `EssentialAction`
    *
    *  @param cu The compilation unit under inspection
    *  @param offset The offset in the compilation unit where the method definition is
@@ -37,7 +37,7 @@ trait ControllerMethodResolver extends PlayClassNames {
 class ScalaControllerMethodResolver extends ControllerMethodResolver with ScalaPlayClassNames {
   /** Extract a controller method from the Scala unit at the given offset.
    *
-   *  A controller method is any method that returns an `Action`.
+   *  A controller method is any method that returns an `EssentialAction`.
    */
   override def getControllerMethod(cu: ICompilationUnit, offset: Int): Option[ControllerMethod] = cu match {
     case scu: ScalaCompilationUnit =>
@@ -51,7 +51,7 @@ class ScalaControllerMethodResolver extends ControllerMethodResolver with ScalaP
           comp.rootMirror.getClassIfDefined(actionClassFullName)
         }
 
-        /* Is the symbol a method returning `play.api.mvc.Action`. */
+        /* Is the symbol a method returning `play.api.mvc.EssentialAction`. */
         def isControllerMethod(sym: comp.Symbol) = (sym ne null) && (sym ne NoSymbol) && (comp.askOption { () =>
           lazy val returnsAction = sym.info.finalResultType.typeSymbol.isSubClass(actionClass)
 


### PR DESCRIPTION
The routes editor should show completions on controller methods returning an `EssentialAction` instead of `Action`.
