### PR TITLE
Code completion on a route editor's action now works on a single word.

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessorTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessorTest.scala
@@ -332,4 +332,60 @@ class ActionContentAssistProcessorTest extends CompletionComputerTest {
 
     route expectedCompletions Proposal("hello(name)", MemberKind.Def, isJava = true)
   }
+  
+  @Test
+  def completion_for_top_level_package() {
+    val route = RouteCompletionFile { "GET / control#" }
+    
+    route expectedCompletions Proposal("controllers", MemberKind.Package)
+  }
+  
+  @Test
+  def completion_for_top_level_package_with_at_prefix() {
+    val route = RouteCompletionFile { "GET / @controll#" }
+    
+    route expectedCompletions Proposal("controllers", MemberKind.Package)
+  }
+  
+  @Test
+  def completion_for_top_level_static_java_method() {
+    val route = RouteCompletionFile { "GET / RootStaticJavaApp#" }
+    
+    route expectedCompletions Proposal("RootStaticJavaApplication", MemberKind.Class, isJava = true)
+  }
+  
+  @Test
+  def completion_for_top_level_static_java_method_with_at_prefix() {
+    val route = RouteCompletionFile { "GET / @RootStaticJavaApp#" }
+
+    route expectedCompletions Proposal("RootStaticJavaApplication", MemberKind.Class, isJava = true)
+  }
+  
+  @Test
+  def completion_for_top_level_scala_class() {
+    val route = RouteCompletionFile { "GET / RootScalaApp#" }
+    
+    route expectedCompletions Proposal("RootScalaApplication", MemberKind.Object)
+  }
+  
+  @Test
+  def completion_for_top_level_scala_class_with_at_prefix() {
+    val route = RouteCompletionFile { "GET / @RootScalaApp#" }
+    
+    route expectedCompletions Proposal("RootScalaApplication", MemberKind.Class)
+  }
+  
+  @Test
+  def completion_for_top_level_scala_package_object() {
+    val route = RouteCompletionFile { "GET / ScalaPack#" }
+    
+    route expectedCompletions Proposal("ScalaPackage", MemberKind.Package)
+  }
+  
+  @Test
+  def completion_for_top_level_scala_package_object_with_at_prefix() {
+    val route = RouteCompletionFile { "GET / @ScalaPack#" }
+    
+    route expectedCompletions Proposal("ScalaPackage", MemberKind.Package)
+  }
 }

--- a/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/app/RootScalaApplication.scala
+++ b/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/app/RootScalaApplication.scala
@@ -1,0 +1,5 @@
+import play.mvc._
+
+class RootScalaApplication {
+  def simple: AnyRef = ???
+}

--- a/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/app/RootStaticJavaApplication.java
+++ b/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/app/RootStaticJavaApplication.java
@@ -1,0 +1,8 @@
+import play.*;
+import play.mvc.*;
+
+public class RootStaticJavaApplication extends Controller {
+	public static Result simple() {
+		return new Result() {};
+	}
+}

--- a/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/app/ScalaPackage/package.scala
+++ b/org.scala-ide.play2.tests/test-workspace/routeActionCompletions/app/ScalaPackage/package.scala
@@ -1,0 +1,3 @@
+package object ScalaPackage {
+	def simple: AnyRef = ???
+}

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/ActionCompletionComputer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/ActionCompletionComputer.scala
@@ -33,7 +33,8 @@ class ActionCompletionComputer(compiler: ScalaPresentationCompiler) {
     * document's region that will be replaced when one of the proposed completions is applied.
     */
   private def computeCompletionOverwriteReplaceRegion(region: IRegion, input: String): IRegion = {
-    val suffixStart = input.lastIndexOf('.') + 1
+    // skip past either the last period or, if there is none, past the starting '@' if one exists.
+    val suffixStart = Math.max(input.lastIndexOf('.'), input.indexOf('@')) + 1
     val suffixOffset = region.getOffset + suffixStart
     val length = Math.max(0, region.getLength - suffixStart)
     new Region(suffixOffset, length)


### PR DESCRIPTION
The problem lied in the MembersLocator subclasses; when creating a MembersComputer they did not handle the case when the prefix was the EmptyPackage. The fix was to handle that case and return the appropriate MembersComputer whose allMembers field was overridden to be the declarations found in the RootClass in addition to the declarations of the prefix itself (i.e. the EmptyPackage).

It should be noted that completion does not work on members of modules or classes found in the default package. However, this should be a separate issue ticket, and should be investigated further to see if play supports action methods coming from these sources before implementing a fix.

Fix #126
