### PR TITLE
Added auto format on save in route editor

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/PlayPlugin.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/PlayPlugin.scala
@@ -17,6 +17,7 @@ object PlayPlugin {
 
   final val PluginId = "org.scala-ide.play2"
   final val RouteFormatterMarginId = PluginId + ".routeeditor.margin"
+  final val RouteFormatterFormatOnSaveId = PluginId + ".routeeditor.formatonsave"
   final val TemplateExtension = "scala.html"
 
   /** Return the current plugin instace */

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/properties/RouteFormatterPreferencePage.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/properties/RouteFormatterPreferencePage.scala
@@ -14,6 +14,9 @@ class RouteFormatterPreferencePage extends FieldEditorPreferencePage with IWorkb
     val marginField = new IntegerFieldEditor(PlayPlugin.RouteFormatterMarginId, "Number of spaces between columns", getFieldEditorParent)
     marginField.setValidRange(1, 10)
     addField(marginField)
+    
+    val formatOnSaveToggle = new org.eclipse.jface.preference.BooleanFieldEditor(PlayPlugin.RouteFormatterFormatOnSaveId, "Format on save", getFieldEditorParent)
+    addField(formatOnSaveToggle);
   }
 
   def init(workbench: IWorkbench) {}


### PR DESCRIPTION
Added an executionEventListener that listens to events, checks the event is a save event, checks that the event originated from the correct route editor instance, checks that the auto format route formatter preference is enabled, and then, if all checks are as expected, formats the route file.

Corresponding preference field was added to the Route Editor's formatter preference page.

Fix #117
