### PR TITLE
Correctly display java method parameter names in route action completion...

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/ActionCompletionComputer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/ActionCompletionComputer.scala
@@ -3,6 +3,7 @@ package org.scalaide.play2.routeeditor.completion.action
 import scala.tools.eclipse.ScalaPresentationCompiler
 import scala.tools.eclipse.completion.MemberKind
 
+import org.eclipse.jdt.core.IMethod
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.IRegion
 import org.eclipse.jface.text.Region
@@ -43,7 +44,19 @@ class ActionCompletionComputer(compiler: ScalaPresentationCompiler) {
     val name = member.decodedName
     member match {
       case m: compiler.MethodSymbol =>
-        val formattedParamss = m.paramss.flatten.map(param => (param.decodedName.toString, param.tpe.toString))
+        lazy val defaultFormattedParamss = m.paramss.flatten.map(param => (param.decodedName.toString, param.tpe.toString))
+        val formattedParamss = m.isJava match {
+          case true  => {
+            val paramNames = compiler.getJavaElement(m) map {
+              case imethod: IMethod => imethod.getParameterNames.toList
+            }
+            paramNames match {
+              case Some(names) => names.zip(m.paramss.flatten.map(_.tpe.toString))
+              case None        => defaultFormattedParamss
+            }
+          }
+          case false => defaultFormattedParamss
+        }
         val controllerMethod = ControllerMethod.apply(member.fullNameString, formattedParamss).toRouteCallSyntax
         val fullyQualifiedMethodCall = {
           // remove empty-parens if member was declared with no-parens. This is nice in general, and especially when when completing Action val. 

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/MembersComputer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/MembersComputer.scala
@@ -32,6 +32,10 @@ private[action] object MembersComputer {
         if (input.prefix.isEmpty) compiler.rootMirror.EmptyPackage
         else prefixSymbol(input)
       }
+      
+      // If the presentation compiler has just been initialized, there is the chance that the symbol has not been initialized,
+      // which means the isJava flag won't be set correctly, which can later cause completion on java symbols to not function.
+      prefix.initialize
       if (prefix == compiler.NoSymbol) {
         logger.debug(s"Could not find a symbol for '${input}'. No completion proposals will be displayed.")
         EmptyMembersComputer


### PR DESCRIPTION
...s

The problem was that when generating parameter names, there was no logic to handle when the symbol is from java code. This fix was to add this logic and and to go fetch a corresponding IMethod from JDT and use it to get the proper name(s) of the parameter(s).

CAVEAT: There all ready existed a passing test for auto completing a java method with parameters that was using the correct/desired parameter names). According to the bug that this commit fixes, that pass should have been failing. We hypothesised that what was happening was that there was no byte code for the java files when running the tests, so the tests were generating java symbol information from the java source files instead (thus giving the proper parameter names). Thus, we tried adding a project build and presentation compiler reset in the test so that the java byte code would be used instead, but that did not reproduce the original bug. Thus, the tests as is don't currently test exactly what we want, and there is no known solution (among Mirco and myself) on how to reproduce this issue in the test suite (however, the issue is easy to produce in an actual eclipse project instance, and I have confirmed that this commit does fix the reported bug there).

Fix #140
