### PR TITLE
'New Template' wizard now correctly validates empty identifier name case...

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/wizards/NewTemplateWizardPage.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/wizards/NewTemplateWizardPage.scala
@@ -47,7 +47,7 @@ class NewTemplateWizardPage(selection: IStructuredSelection) extends WizardNewFi
         false
       }
     } else {
-      true
+      false
     }
   }
 


### PR DESCRIPTION
....

In validatePage, if super.validatePage() returned false, then we would return true… So, the change was to return false :)

Fix #141
