### PR TITLE
URI renaming of invalid/local paths in route editor

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/RouteUriTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/RouteUriTest.scala
@@ -9,6 +9,53 @@ class RouteUriTest {
   def parsingSimple {
     val route = RouteUri("/ab/cd/ef")
     assertEquals("Wrong uri parsing", List("ab", "cd", "ef"), route.parts)
+    assertEquals("Wrong validity [should be true/valid]", true, route.isValid)
   }
   
+  @Test
+  def parsingInvalid {
+    val route = RouteUri("ab/cd/ef")
+    assertEquals("Wrong uri parsing", List("ab", "cd", "ef"), route.parts)
+    assertEquals("Wrong validity [should be false/invalid]", false, route.isValid)
+  }
+  
+  @Test
+  def prefixLengthNoPrefix {
+    testPrefixLength("/ab", List(), 1)
+  }
+  
+  @Test
+  def prefixLengthNoMatch {
+    testPrefixLength("/ab", List("ba"), -1)
+  }
+  
+  @Test
+  def prefixLengthWholeMatch {
+    testPrefixLength("/ab/cd", List("ab", "cd"), 6)
+  }
+  
+  @Test
+  def prefixLengthPrefixMatch {
+    testPrefixLength("/ab/cd", List("ab"), 4)
+  }
+  
+  @Test
+  def prefixLengthInvalidUri {
+    testPrefixLength("ab/cd", List("ab"), 3)
+  }
+  
+  @Test
+  def prefixLengthEmptyUri {
+    testPrefixLength("/", List(), 1)
+  }
+  
+  @Test
+  def prefixLengthEmptyInvalidUri {
+    testPrefixLength("", List(), 0)
+  }
+  
+  private def testPrefixLength(rawUri: String, prefixParts: List[String], expectedLength: Int) {
+    val route = RouteUri(rawUri)
+    assertEquals("Wrong prefix length", expectedLength, route.prefixLength(prefixParts))
+  }
 }

--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/handlers/LocalRenameTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/handlers/LocalRenameTest.scala
@@ -13,6 +13,25 @@ import org.eclipse.jface.text.TextSelection
 class LocalRenameTest extends RouteTest {
 
   @Test
+  def replaceSingleLocationOnInvalidPath {
+    testLocations("GET %pa@th%")
+  }
+
+  @Test
+  def replaceLocationsOnInvalidPaths {
+    testLocations(
+      """GET %path%
+        |GET %pa@th%/abc""")
+  }
+  
+  @Test
+  def replaceLocationsOnValidAndInvalidPaths {
+    testLocations(
+      """GET %path%
+        |GET /%pa@th%""")
+  }
+
+  @Test
   def replaceLocationsNoSelection {
     testLocations(
       """GET /path/%abc%/def  controller

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/UriCompletionComputer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/UriCompletionComputer.scala
@@ -38,17 +38,18 @@ class UriCompletionComputer extends IContentAssistProcessor {
     val existingUris = RouteUriWithRegion.existingUrisInDocument(document).filter(_ != uri)
 
     // If the `rawUri` is empty then add '/' to the returned set of proposals 
-    val defaultUriProposal = if (rawUri.isEmpty) Set(uri) else Set.empty 
+    val defaultUriProposal = if (rawUri.isEmpty) Set(RouteUri("/")) else Set.empty 
     
     val staticUrisProposals = {
-      if (RouteUri.isValid(rawUri)) existingUris.flatMap(_.subUrisStartingWith(rawUri))
+      if (RouteUri(rawUri).isValid) existingUris.flatMap(_.subUrisStartingWith(rawUri))
       // If the `rawUri` isn't valid, then proposals will contain all possible valid permutations of existing URIs
       else existingUris.flatMap(_.subUrisStartingWith(""))
     }
 
     val dynamicUrisProposals = {
-      // Add dynamics parts to the proposals only if completion happens on an empty URI or after a slash 
-      if (rawUri.isEmpty || rawUri.last == '/') RouteUri(rawUri).dynamicUris
+      // Add dynamics parts to the proposals only if completion happens on an empty URI or after a slash
+      if (rawUri.isEmpty) RouteUri("/").dynamicUris
+      else if (rawUri.last == '/') RouteUri(rawUri).dynamicUris
       else staticUrisProposals
     }
  


### PR DESCRIPTION
There was an off-by-one when try rename paths that didn't start with a leading '/'. In actuality, these types of paths are not accepted by play, which is why they were not handled correctly. The fix was to simply detect invalid paths and adjust the offset of the corresponding to-be-highlighted regions.

Fix #137
