### PR TITLE
HTTP method completion work's at beginning of line

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/TestSuite.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/TestSuite.scala
@@ -2,6 +2,7 @@ package org.scalaide.play2
 
 import org.junit.runner.RunWith
 import org.junit.runners.Suite.SuiteClasses
+import org.scalaide.play2.lexical.PlayDocumentPartitionerTests
 import org.scalaide.play2.quickassist.ControllerMethodTest
 import org.scalaide.play2.quickassist.ResolverTest
 import org.scalaide.play2.routeeditor.completion.ActionContentAssistProcessorTest
@@ -12,6 +13,7 @@ import org.scalaide.play2.routeeditor.completion.ActionContentAssistProcessorTes
     classOf[TemplateTestSuite],
     classOf[ControllerMethodTest],
     classOf[ActionContentAssistProcessorTest],
-    classOf[ResolverTest]
+    classOf[ResolverTest],
+    classOf[PlayDocumentPartitionerTests]
 ))
 class TestSuite

--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/lexical/PlayDocumentPartitionerTests.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/lexical/PlayDocumentPartitionerTests.scala
@@ -1,0 +1,51 @@
+package org.scalaide.play2.lexical
+
+import org.junit.Test
+import org.junit.Before
+import org.junit.Assert._
+import org.eclipse.jface.text.IDocument
+import org.eclipse.jface.text.Document
+import org.eclipse.jface.text.TypedRegion
+import org.scalaide.play2.routeeditor.RouteTest
+import org.scalaide.play2.routeeditor.lexical.RoutePartitions
+import com.sun.org.apache.xalan.internal.xsltc.compiler.RoundCall
+
+class PlayDocumentPartitionerTests extends RouteTest {
+  
+  @Test
+  def httpToken {
+    testToken("G%ET / controller", new TypedRegion(0, 3, RoutePartitions.ROUTE_HTTP))
+  }
+  
+  @Test
+  def uriToken {
+    testToken("GET /path/p%ath controller", new TypedRegion(4, 10, RoutePartitions.ROUTE_URI))
+  }
+  
+  @Test
+  def actionToken {
+    testToken("GET / contro%ller", new TypedRegion(6, 10, RoutePartitions.ROUTE_ACTION))
+  }
+  
+  @Test
+  def beginningOfFileDefaultToken {
+    testToken(" % GET / controller", new TypedRegion(0, 2, RoutePartitions.ROUTE_DEFAULT))
+  }
+  
+  @Test
+  def endOfFileDefaultToken {
+    testToken("GET / controller %", new TypedRegion(17, 0, RoutePartitions.ROUTE_DEFAULT))
+  }
+  
+  @Test
+  def surroundedDefaultToken {
+    testToken("GET %  / controller", new TypedRegion(3, 3, RoutePartitions.ROUTE_DEFAULT))
+  }
+  
+  private def testToken(rawContent: String, expectedToken: TypedRegion) = {
+    val file = RouteFile(rawContent, List('%'))
+    val caretOffset = file.caretOffset('%')
+    val partition = file.document.getPartition(caretOffset)
+    assertEquals("Unexpected token", expectedToken, partition)
+  }
+}

--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/RouteTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/RouteTest.scala
@@ -88,7 +88,7 @@ trait RouteTest {
         }
       }
       
-      extractPositions(text.toList, 0, new StringBuilder(), markers.map(c => (c, Nil)).toMap)
+      extractPositions(rawText.toList, 0, new StringBuilder(), markers.map(c => (c, Nil)).toMap)
     }
   }
   

--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/HttpMethodCompletionComputerTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/HttpMethodCompletionComputerTest.scala
@@ -66,6 +66,12 @@ class HttpMethodCompletionComputerTest extends CompletionComputerTest {
 
     route expectedCompletions (AllHttpMethodsProposals: _*)
   }
+  
+  @Test
+  def all_Http_Method_completetion_at_beginning_of_empty_preceded_by_empty_line() {
+    val route = RouteCompletionFile { "\n@" }
+    route expectedCompletions (AllHttpMethodsProposals: _*)
+  }
 
   @Test
   def all_Http_Method_completion_at_end_of_empty_line() {

--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/lexical/RoutePartitionTokeniserTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/lexical/RoutePartitionTokeniserTest.scala
@@ -59,14 +59,14 @@ class RoutePartitionTokeniserTest {
   def empty_lines_tokenized_as_HTPP_partitions() {
     val text = s" \n"
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 1, ROUTE_HTTP), new TypedRegion(1, 1, ROUTE_DEFAULT), new TypedRegion(2, 0, ROUTE_HTTP)), tokens)
+    Assert.assertEquals(List(new TypedRegion(0, 1, ROUTE_HTTP), new TypedRegion(2, 0, ROUTE_HTTP)), tokens)
   }
 
   @Test
   def GET_followed_by_newline_are_both_partitioned_as_HTTP_partitions() {
     val text = s"GET \n"
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(3, 1, ROUTE_DEFAULT), new TypedRegion(4, 0, ROUTE_URI), new TypedRegion(4, 1, ROUTE_DEFAULT), new TypedRegion(5, 0, ROUTE_HTTP)), tokens)
+    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(4, 0, ROUTE_URI), new TypedRegion(5, 0, ROUTE_HTTP)), tokens)
   }
 
   /** This test shows that when no HTTP method is found, the first word in the line is always partitioned as a ROUTE_HTTP.
@@ -79,56 +79,56 @@ class RoutePartitionTokeniserTest {
   def when_HTTP_method_is_missing_URI_is_partitioned_as_HTTP_method() {
     val text = " /public"
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 1, ROUTE_DEFAULT), new TypedRegion(1, 7, ROUTE_HTTP)), tokens)
+    Assert.assertEquals(List(new TypedRegion(1, 7, ROUTE_HTTP)), tokens)
   }
 
   @Test
   def URI_partition_is_always_expected_after_HTTP_partition() {
     val text = "GET "
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(3, 1, ROUTE_DEFAULT), new TypedRegion(4, 0, ROUTE_URI)), tokens)
+    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(4, 0, ROUTE_URI)), tokens)
   }
 
   @Test
   def simple_URI_after_HTTP_is_correctly_partitioned() {
     val text = "GET /public"
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(3, 1, ROUTE_DEFAULT), new TypedRegion(4, 7, ROUTE_URI)), tokens)
+    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(4, 7, ROUTE_URI)), tokens)
   }
 
   @Test
   def URI_with_dynamic_part_after_HTTP_is_correctly_partitioned() {
     val text = "GET /clients/:id controllers.Clients.show(id: Long)"
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(3, 1, ROUTE_DEFAULT), new TypedRegion(4, 12, ROUTE_URI), new TypedRegion(16, 1, ROUTE_DEFAULT), new TypedRegion(17, 34, ROUTE_ACTION)), tokens)
+    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(4, 12, ROUTE_URI), new TypedRegion(17, 34, ROUTE_ACTION)), tokens)
   }
 
   @Test
   def action_after_HTTP_and_URI_is_expected() {
     val text = "GET /public  "
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(3, 1, ROUTE_DEFAULT), new TypedRegion(4, 7, ROUTE_URI), new TypedRegion(11, 1, ROUTE_DEFAULT), new TypedRegion(12, 1, ROUTE_ACTION)), tokens)
+    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(4, 7, ROUTE_URI), new TypedRegion(12, 1, ROUTE_ACTION)), tokens)
   }
 
   @Test
   def action_after_HTTP_and_URI_is_correctly_partitioned() {
     val text = "GET /public controllers.Home.welcome()"
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(3, 1, ROUTE_DEFAULT), new TypedRegion(4, 7, ROUTE_URI), new TypedRegion(11, 1, ROUTE_DEFAULT), new TypedRegion(12, 26, ROUTE_ACTION)), tokens)
+    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(4, 7, ROUTE_URI), new TypedRegion(12, 26, ROUTE_ACTION)), tokens)
   }
 
   @Test
   def whitespace_after_action_are_not_included_in_partition() {
     val text = "GET /public controllers.Home.welcome()  " // the trailing whitespaces are relevant for this test! 
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(3, 1, ROUTE_DEFAULT), new TypedRegion(4, 7, ROUTE_URI), new TypedRegion(11, 1, ROUTE_DEFAULT), new TypedRegion(12, 26, ROUTE_ACTION), new TypedRegion(38, 2, ROUTE_DEFAULT)), tokens)
+    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(4, 7, ROUTE_URI), new TypedRegion(12, 26, ROUTE_ACTION)), tokens)
   }
   
   @Test
   def whitespace_in_action_is_correctly_managed() {
     val text = "GET /public controllers.Home.welcome(name, value)" 
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(3, 1, ROUTE_DEFAULT), new TypedRegion(4, 7, ROUTE_URI), new TypedRegion(11, 1, ROUTE_DEFAULT), new TypedRegion(12, 37, ROUTE_ACTION)), tokens)
+    Assert.assertEquals(List(new TypedRegion(0, 3, ROUTE_HTTP), new TypedRegion(4, 7, ROUTE_URI), new TypedRegion(12, 37, ROUTE_ACTION)), tokens)
   }
   
   @Test
@@ -142,6 +142,6 @@ class RoutePartitionTokeniserTest {
   def badCommentLeadingSpace() {
     val text = " # some blabla"
     val tokens = tokenizer.tokenise(text)
-    Assert.assertEquals(List(new TypedRegion(0, 1, ROUTE_DEFAULT), new TypedRegion(1, 1, ROUTE_HTTP), new TypedRegion(2, 1, ROUTE_DEFAULT), new TypedRegion(3,4, ROUTE_URI), new TypedRegion(7, 1, ROUTE_DEFAULT), new TypedRegion(8, 6, ROUTE_ACTION)), tokens)
+    Assert.assertEquals(List(new TypedRegion(1, 1, ROUTE_HTTP), new TypedRegion(3,4, ROUTE_URI), new TypedRegion(8, 6, ROUTE_ACTION)), tokens)
   }
 }

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/lexical/RoutePartitionTokeniser.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/lexical/RoutePartitionTokeniser.scala
@@ -102,13 +102,7 @@ class RoutePartitionTokeniser extends PlayPartitionTokeniser {
     })(collection.breakOut)
   }
 
-  override def tokenise(document: IDocument): List[TypedRegion] = {
-    import org.scalaide.editor.util.RegionHelper._
-    
-    val lines = convertToSeperateLines(document)
-    val allRegions = lines.flatMap(tokeniseEachLine(document, _))
-    
-    val defaultRegions = List(new TypedRegion(0, document.getLength(), ROUTE_DEFAULT)) \ allRegions
-    defaultRegions U allRegions
-  }
+  override def tokenise(document: IDocument): List[TypedRegion] =
+    convertToSeperateLines(document).flatMap(tokeniseEachLine(document, _))
+ 
 }


### PR DESCRIPTION
The issue beforehand was that the tokenizer was inserting default tokens to fill any non-contiguous areas. However, this would cause problems when there existed zero-length http method tokens (the default token would precede the method token, and "overlap" with it, thus taking precedence). The fix was to remove the manually inserted default tokens, and instead return the a default token that fills the contiguous area from the getPartition() method of the PlayDocumentPartitioner if a token at the requested caret offset can not be found.

Fix #129
