### PR TITLE
Changed shortcut for URI renaming in route editor

### DIFF
--- a/org.scala-ide.play2/plugin.xml
+++ b/org.scala-ide.play2/plugin.xml
@@ -131,7 +131,7 @@
             commandId="org.scala-ide.play2.routeeditor.commands.rename"
             contextId="org.scala-ide.play2.routeeditor.editorScope"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            sequence="M2+M3+R">
+            sequence="M1+M3+R">
       </key>
    </extension>
    <extension


### PR DESCRIPTION
Changed the shortcut from ALT+SHIFT+R to CMD+ALT+R

Fix #144
