### PR TITLE
Scanner classes no longer need a `colorManager`

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/lexical/AbstractRouteScannerTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/lexical/AbstractRouteScannerTest.scala
@@ -7,11 +7,9 @@ import org.eclipse.jface.text.rules.Token
 import org.junit.Assert.assertEquals
 import org.scalaide.play2.PlayPlugin
 
-abstract class AbstractRouteScannerTest(constructor: (IPreferenceStore, IColorManager) => AbstractRouteScanner) {
-//  protected val colorManager = new JavaColorManager()
-  protected val colorManager = null
+abstract class AbstractRouteScannerTest {
   protected val prefStore = PlayPlugin.preferenceStore
-  protected val scanner = constructor(prefStore, colorManager);
+  protected val scanner : AbstractRouteScanner
   protected val defaultToken = scanner.getDefaultReturnToken
   protected val wsToken = Token.WHITESPACE
   protected val eofToken = Token.EOF

--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/lexical/RouteActionScannerTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/lexical/RouteActionScannerTest.scala
@@ -5,7 +5,9 @@ import org.eclipse.jface.text.rules.IToken
 import org.eclipse.jface.text.rules.Token
 import org.junit.Test
 
-class RouteActionScannerTest extends AbstractRouteScannerTest(new RouteActionScanner(_, _)) {
+class RouteActionScannerTest extends AbstractRouteScannerTest {
+  override val scanner = new RouteActionScanner(prefStore)
+  
   val packageToken = scanner.asInstanceOf[RouteActionScanner].packageToken
   val classToken = scanner.asInstanceOf[RouteActionScanner].classToken
   val methodToken = scanner.asInstanceOf[RouteActionScanner].methodToken

--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/lexical/RouteURIScannerTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/lexical/RouteURIScannerTest.scala
@@ -5,7 +5,9 @@ import org.eclipse.jface.text.rules.IToken
 import org.eclipse.jface.text.rules.Token
 import org.junit.Test
 
-class RouteURIScannerTest extends AbstractRouteScannerTest(new RouteURIScanner(_, _)) {
+class RouteURIScannerTest extends AbstractRouteScannerTest {
+  override val scanner = new RouteURIScanner(prefStore)
+
   private val dynamicToken = scanner.asInstanceOf[RouteURIScanner].dynamic
 
   @Test

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/RoutePresentationReconciler.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/RoutePresentationReconciler.scala
@@ -15,22 +15,20 @@ import org.scalaide.play2.routeeditor.lexical.RouteURIScanner
 
 class RoutePresentationReconciler(prefStore: IPreferenceStore) extends PresentationReconciler with PropertyChangeHandler {
 
-  private val colorManager = new JavaColorManager()
-
   private val scanner =
-    new SingleTokenScanner(RouteSyntaxClasses.DEFAULT, colorManager, prefStore)
+    new SingleTokenScanner(RouteSyntaxClasses.DEFAULT, prefStore)
 
   private val httpScanner =
-    new SingleTokenScanner(RouteSyntaxClasses.HTTP_KEYWORD, colorManager, prefStore)
+    new SingleTokenScanner(RouteSyntaxClasses.HTTP_KEYWORD, prefStore)
 
   private val uriScanner =
-    new RouteURIScanner(prefStore, colorManager)
+    new RouteURIScanner(prefStore)
 
   private val actionScanner =
-    new RouteActionScanner(prefStore, colorManager)
+    new RouteActionScanner(prefStore)
 
   private val commentScanner =
-    new SingleTokenScanner(RouteSyntaxClasses.COMMENT, colorManager, prefStore)
+    new SingleTokenScanner(RouteSyntaxClasses.COMMENT, prefStore)
 
   handlePartition(scanner, RoutePartitions.ROUTE_DEFAULT)
   handlePartition(httpScanner, RoutePartitions.ROUTE_HTTP)

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/lexical/AbstractRouteScanner.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/lexical/AbstractRouteScanner.scala
@@ -7,10 +7,9 @@ import org.eclipse.jdt.ui.text.IColorManager
 import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.text.rules.RuleBasedScanner
 
-abstract class AbstractRouteScanner(defaultSyntax: ScalaSyntaxClass, prefStore: IPreferenceStore, manager: IColorManager) extends RuleBasedScanner with AbstractScalaScanner {
+abstract class AbstractRouteScanner(defaultSyntax: ScalaSyntaxClass, prefStore: IPreferenceStore) extends RuleBasedScanner with AbstractScalaScanner {
   fDefaultReturnToken = getToken(defaultSyntax)
   override def preferenceStore = prefStore
-  override def colorManager = manager
 
   def getDefaultReturnToken = fDefaultReturnToken
 

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/lexical/RouteActionScanner.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/lexical/RouteActionScanner.scala
@@ -12,7 +12,7 @@ import org.scalaide.play2.routeeditor.RouteSyntaxClasses.ACTION_PACKAGE
 /**
  * scanner for action part of route file
  */
-class RouteActionScanner(prefStore: IPreferenceStore, manager: IColorManager) extends AbstractRouteScanner(ACTION, prefStore, manager) {
+class RouteActionScanner(prefStore: IPreferenceStore) extends AbstractRouteScanner(ACTION, prefStore) {
 
   val packageToken = getToken(ACTION_PACKAGE);
   val classToken = getToken(ACTION_CLASS);

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/lexical/RouteURIScanner.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/lexical/RouteURIScanner.scala
@@ -10,7 +10,7 @@ import org.scalaide.play2.routeeditor.RouteSyntaxClasses.URI_DYNAMIC
 /**
  * scanner for URI part of route file
  */
-class RouteURIScanner(prefStore: IPreferenceStore, manager: IColorManager) extends AbstractRouteScanner(URI, prefStore, manager) {
+class RouteURIScanner(prefStore: IPreferenceStore) extends AbstractRouteScanner(URI, prefStore) {
   def dynamic = getToken(URI_DYNAMIC)
 
   val rules = Array[IRule](

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateConfiguration.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateConfiguration.scala
@@ -45,19 +45,18 @@ import org.scalaide.editor.EditorUI
 
 class TemplateConfiguration(prefStore: IPreferenceStore, templateEditor: TemplateEditor) extends TextSourceViewerConfiguration(prefStore) with PropertyChangeHandler {
 
-  val colorManager = new JavaColorManager()
   private val templateDoubleClickStrategy =
     new RouteDoubleClickStrategy()
 
-  private val defaultScanner = new TemplateDefaultScanner(colorManager, prefStore)
+  private val defaultScanner = new TemplateDefaultScanner(prefStore)
 
-  private val plainScanner = new SingleTokenScanner(TemplateSyntaxClasses.PLAIN, colorManager, prefStore)
+  private val plainScanner = new SingleTokenScanner(TemplateSyntaxClasses.PLAIN, prefStore)
 
-  private val scalaScanner = new ScalaCodeScanner(colorManager, prefStore, ScalaVersions.Scala_2_10)
+  private val scalaScanner = new ScalaCodeScanner(prefStore, ScalaVersions.Scala_2_10)
 
-  private val commentScanner = new SingleTokenScanner(TemplateSyntaxClasses.COMMENT, colorManager, prefStore)
+  private val commentScanner = new SingleTokenScanner(TemplateSyntaxClasses.COMMENT, prefStore)
 
-  private val tagScanner = new HtmlTagScanner(colorManager, prefStore)
+  private val tagScanner = new HtmlTagScanner(prefStore)
 
   override def getDoubleClickStrategy(sourceViewer: ISourceViewer, contentType: String) = {
     templateDoubleClickStrategy

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/HtmlTagScanner.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/HtmlTagScanner.scala
@@ -7,7 +7,7 @@ import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.rules.IToken
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClasses._
 
-class HtmlTagScanner(_colorManager: IColorManager, _preferenceStore: IPreferenceStore) extends XmlTagScanner(_colorManager, _preferenceStore) {
+class HtmlTagScanner(preferenceStore: IPreferenceStore) extends XmlTagScanner(preferenceStore) {
   import XmlTagScanner._
 
   var start: Int = -1

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplateDefaultScanner.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplateDefaultScanner.scala
@@ -8,7 +8,7 @@ import org.eclipse.jface.text.rules.WordRule
 import org.scalaide.play2.routeeditor.lexical.AbstractRouteScanner
 import org.scalaide.play2.templateeditor.TemplateSyntaxClasses
 
-class TemplateDefaultScanner(manager: IColorManager, prefStore: IPreferenceStore) extends AbstractRouteScanner(TemplateSyntaxClasses.DEFAULT, prefStore, manager) {
+class TemplateDefaultScanner(prefStore: IPreferenceStore) extends AbstractRouteScanner(TemplateSyntaxClasses.DEFAULT, prefStore) {
   val atToken = getToken(TemplateSyntaxClasses.MAGIC_AT);
   val braceToken = getToken(TemplateSyntaxClasses.BRACE);
 


### PR DESCRIPTION
Updated codebase to comply with
scala-ide/scala-ide@SHA: 7d846dfdb40a0dd5c5f9ab6376931d1322ef0130
