### PR TITLE
Updated junit bundle names in manifest files.

### DIFF
--- a/org.scala-ide.play2.tests/META-INF/MANIFEST.MF
+++ b/org.scala-ide.play2.tests/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Fragment-Host: org.scala-ide.play2
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.scala-ide.scala.library,
  org.eclipse.equinox.weaving.aspectj,
- org.junit4;bundle-version="4.5.0",
+ org.junit;bundle-version="4.5.0",
  org.scala-ide.sdt.core
 Import-Package: scala.tools.eclipse.testsetup,
  org.aspectj.weaver.loadtime.definition

--- a/org.scala-ide.sdt.editor.tests/META-INF/MANIFEST.MF
+++ b/org.scala-ide.sdt.editor.tests/META-INF/MANIFEST.MF
@@ -9,6 +9,6 @@ Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Import-Package: scala.tools.eclipse.testsetup,
  org.aspectj.weaver.loadtime.definition
 Require-Bundle: 
- org.junit4
+ org.junit
 Bundle-ClassPath: .,
  target/lib/mockito-all-1.9.0.jar


### PR DESCRIPTION
In the upgrade to Eclipse 4.x, the junit bundle names changed from 'org.junit4' to 'org.junit'.
