### PR TITLE
Multiple spanned XML doc regions and "reusable code blocks" syntax highlighting fixes.

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/templateeditor/lexical/TemplatePartitionTokniserTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/templateeditor/lexical/TemplatePartitionTokniserTest.scala
@@ -4,7 +4,6 @@ import org.junit.Test
 import org.junit.Assert._
 import scala.tools.eclipse.testsetup.TestProjectSetup
 import org.eclipse.jdt.core.IJavaElement
-import TemplatePartitionTokeniser._
 import org.eclipse.jdt.core.IMethod
 import org.eclipse.jdt.core.Signature
 import org.eclipse.jface.text.TypedRegion
@@ -12,9 +11,9 @@ import org.eclipse.jface.text.TypedRegion
 import org.junit.AfterClass
 import scala.tools.eclipse.testsetup.SDTTestUtils
 import org.eclipse.jface.text.IDocument
-import org.eclipse.jface.text.Document
 import org.scalaide.editor.util.RegionHelper._
 import scala.annotation.tailrec
+import org.eclipse.jdt.internal.core.util.SimpleDocument
 
 class TemplatePartitionTokeniserTest {
 
@@ -69,7 +68,8 @@ val x = "x string"
   }
 
   private def testForTokenise(expected: List[TypedRegion], program: String) = {
-    val actual = tokenise(new Document(program))
+    val tokeniser = new TemplatePartitionTokeniser
+    val actual = tokeniser.tokenise(new SimpleDocument(program))
 
     @tailrec
     def noOverlap(list: List[TypedRegion]): Boolean = {

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplateDocumentPartitioner.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplateDocumentPartitioner.scala
@@ -6,7 +6,7 @@ import TemplatePartitions.TEMPLATE_DEFAULT
 import TemplatePartitions.TEMPLATE_SCALA
 import org.eclipse.jface.text.ITypedRegion
 
-class TemplateDocumentPartitioner(conservative: Boolean = false) extends PlayDocumentPartitioner(TemplatePartitionTokeniser, TemplatePartitions.TEMPLATE_DEFAULT, conservative) {
+class TemplateDocumentPartitioner(conservative: Boolean = false) extends PlayDocumentPartitioner(new TemplatePartitionTokeniser, TemplatePartitions.TEMPLATE_DEFAULT, conservative) {
 
   import TemplateDocumentPartitioner._
 

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplatePartitionTokeniser.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplatePartitionTokeniser.scala
@@ -13,23 +13,18 @@ import org.scalaide.play2.lexical.PlayPartitionTokeniser
 import scala.collection.mutable.ArrayBuffer
 import org.scalaide.editor.util.RegionHelper._
 
-object TemplatePartitionTokeniser extends PlayPartitionTokeniser {
+class TemplatePartitionTokeniser extends PlayPartitionTokeniser {
 
-  /**
-   * calculates XML tag regions by using scala partition tokensier
-   */
-  def getXMLTagRegions(templateCode: String): List[TypedRegion] = {
-    val toks = ScalaPartitionTokeniser.tokenise(templateCode)
-    val newToks = toks.filter(_.contentType == ScalaPartitions.XML_TAG).map(t => {
+  /** Calculates XML tag regions by using scala partition tokensier. */
+  private def getXMLTagRegions(templateCode: String): List[TypedRegion] = {
+    val tokens = ScalaPartitionTokeniser.tokenise(templateCode)
+    tokens.filter(_.contentType == ScalaPartitions.XML_TAG).map(t => {
       new TypedRegion(t.start, t.length, TemplatePartitions.TEMPLATE_TAG)
     })
-    newToks
   }
 
-  /**
-   * calculates scala, comment, and plain regions using template parser
-   */
-  def getScalaCommentAndPlainRegions(templateCode: String): (List[TypedRegion], List[TypedRegion]) = {
+  /** Calculates scala, comment, and plain regions using template parser. */
+  private def getScalaCommentAndPlainRegions(templateCode: String): (List[TypedRegion], List[TypedRegion]) = {
     val parts = TemplateParsing.handleTemplateCode(templateCode)
     import TemplateParsing._
     val tokens: List[TypedRegion] = parts.map(t => {
@@ -40,21 +35,21 @@ object TemplatePartitionTokeniser extends PlayPartitionTokeniser {
       }
       new TypedRegion(t.offset, t.length, contentType)
     })
-    val sortedUsefulRegions = tokens.filter(e => (e.getOffset() != -1)&&(e.getLength() > 0)).sortWith((a, b) => a.getOffset() < b.getOffset())
+    val sortedUsefulRegions = tokens.filter(e => (e.getOffset() != -1) && (e.getLength() > 0)).sortWith((a, b) => a.getOffset() < b.getOffset())
     val plainRegions = sortedUsefulRegions.filter(e => e.getType() == TemplatePartitions.TEMPLATE_PLAIN)
     val scalaCommentRegions = sortedUsefulRegions.filter(e => e.getType() != TemplatePartitions.TEMPLATE_PLAIN)
     (scalaCommentRegions, plainRegions)
   }
 
-  /**
-   * calculates the template partitions.
+  /** 
+   * Calculates the template partitions.
    * 
    * @param xmlTagPlainRegions 			tags which are plain text, which means are represented to user
    * @param scalaCommentRegions			scala and comment regions
    * @param plainWithoutXmlTagRegions 	plain texts which are not part of tag
    * @param templateCode				template code which we'd like to tokenise
    */
-  def calculateAllRegions(xmlTagPlainRegions: List[TypedRegion], scalaCommentRegions: List[TypedRegion], plainWithoutXmlTagRegions: List[TypedRegion], templateCode: String): List[TypedRegion] = {
+  private def calculateAllRegions(xmlTagPlainRegions: List[TypedRegion], scalaCommentRegions: List[TypedRegion], plainWithoutXmlTagRegions: List[TypedRegion], templateCode: String): List[TypedRegion] = {
     def defaultRegion(start: Int, offset: Int) =
       new TypedRegion(start, offset, TemplatePartitions.TEMPLATE_DEFAULT)
     val allRegions = (xmlTagPlainRegions U scalaCommentRegions) U plainWithoutXmlTagRegions
@@ -63,7 +58,7 @@ object TemplatePartitionTokeniser extends PlayPartitionTokeniser {
     allRegions U defaultRegions
   }
 
-  def tokenise(template: IDocument): List[TypedRegion] = 
+  override final def tokenise(template: IDocument): List[TypedRegion] = 
     tokenise(template.get)
 
   def tokenise(templateCode: String): List[TypedRegion] = {

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/lexical/PartitionHelpers.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/lexical/PartitionHelpers.scala
@@ -4,43 +4,68 @@ import org.eclipse.jface.text.ITypedRegion
 import org.eclipse.jface.text.TypedRegion
 import org.scalaide.play2.templateeditor.lexical.TemplatePartitions
 import scala.collection.mutable.ArrayBuffer
-import scala.collection.mutable.ListBuffer
+import scala.annotation.tailrec
 
 object PartitionHelpers {
+
   def isMagicAt(token: ITypedRegion, codeString: String) = {
-    val s = codeString.substring(token.getOffset(), token.getOffset() + token.getLength()).trim
-    token.getType() == TemplatePartitions.TEMPLATE_DEFAULT && s.length == 1 && s == "@"
+    def tokenText = textOf(token, codeString).trim
+    token.getType() == TemplatePartitions.TEMPLATE_DEFAULT && tokenText == "@"
   }
   
   def isBrace(token: ITypedRegion, codeString: String) = {
-    val s = codeString.substring(token.getOffset(), token.getOffset() + token.getLength()).trim
-    token.getType() == TemplatePartitions.TEMPLATE_DEFAULT && s.length > 0 && s.foldLeft(true)((r, c) => r && (c == '{' || c == '}' || c.isWhitespace))
+    def tokenText = textOf(token, codeString).trim
+    token.getType() == TemplatePartitions.TEMPLATE_DEFAULT && tokenText.length > 0 && tokenText.foldLeft(true)((r, c) => r && (c == '{' || c == '}' || c.isWhitespace))
   }
-  
-  private def detectSequence(codeString: String, fs: ListBuffer[Char => Boolean], marked: Int, isIgnored: Char => Boolean): Option[Int] = {
-    var sawBadChar = false
-    var index = -1
-    var currentF = 0
-    for (i <- 0 to codeString.length() - 1) {
-      val c = codeString(i)
-      if (fs.isEmpty) 
-        sawBadChar = sawBadChar || (!isIgnored(c))
-      else {
-        if (fs.head(c)) {
-          if (currentF == marked)
-            index = i
-          fs.remove(0)
-          currentF += 1
-        }
-        else
-          sawBadChar = sawBadChar || (!isIgnored(c))
+
+  private def textOf(token: ITypedRegion, documentContent: String): String = 
+    documentContent.substring(token.getOffset(), token.getOffset() + token.getLength())
+
+  /**
+   * Detect each "character sequence function" in turn, and return the offset in `codeString` at which the `sequenceFuncs(marked)` was detected (returned true)
+   *  If you do not particularly care where the offset of a specific sequence function was detected, the value passed to `marked` does not matter.
+   *  @return Sequence detection success will be marked of a `Some` value being returned, with the codeString offset corresponding to `marked` being the value of the `Some`.
+   */
+  private def detectSequence(codeString: String, sequenceFuncs: List[Char => Boolean], marked: Int, isIgnored: Char => Boolean): Option[Int] = {
+
+    @tailrec
+    def loop(code: List[Char], sequenceFuncs: List[Char => Boolean], toMarked: Int, index: Int, indexMarked: Int): Option[Int] = {
+      code match {
+        case Nil =>
+          if (sequenceFuncs.isEmpty) {
+            // codeString and sequence terminated at the same time, all good
+            Some(indexMarked)
+          } else {
+            // codeString terminated, but not the sequence
+            None
+          }
+        case c :: codeTail =>
+          sequenceFuncs match {
+            case Nil =>
+              // found all elements of the sequence, check if all the remainder chars are to be ignored
+              if (code.forall(isIgnored)) {
+                Some(indexMarked)
+              } else {
+                None
+              }
+            case f :: fTail =>
+              if (f(c)) {
+                // right character for the sequence
+                if (toMarked == 0) { // keep track of the index if needed
+                  loop(codeTail, fTail, -1, index + 1, index)
+                } else {
+                  loop(codeTail, fTail, toMarked - 1, index + 1, indexMarked)
+                }
+              } else if (isIgnored(c)) { // continue if the char can be ignored
+                loop(codeTail, sequenceFuncs, toMarked, index + 1, indexMarked)
+              } else { // char not in sequence and not to be ignored
+                None
+              }
+          }
       }
     }
-    
-    if(fs.isEmpty && !sawBadChar)
-      Some(index)
-    else
-      None
+
+    loop(codeString.toList, sequenceFuncs, marked, 0, -1)
   }
 
   /**
@@ -49,22 +74,21 @@ object PartitionHelpers {
    *  - Corresponding text matches the following pseudo-regex: (spaceOrTab?)('{' | '}')(spaceOrTab?)('@')(spaceOrTab?)
    */
   def isCombinedBraceMagicAt(token: ITypedRegion, codeString: String): Boolean = {
-    val s = codeString.substring(token.getOffset(), token.getOffset() + token.getLength())
+    def tokenText = textOf(token, codeString)
     if(token.getType() == TemplatePartitions.TEMPLATE_DEFAULT) {
-      val firstBrace = {c: Char => c == '{' || c == '}'}
-      val secondAt = {c: Char => c == '@'}
+      val isBrace = {c: Char => c == '{' || c == '}'}
+      val isAt = {c: Char => c == '@'}
       val ignored = {c: Char => c == ' ' || c == '\t'}
-      detectSequence(s, ListBuffer(firstBrace, secondAt), 0, ignored).isDefined
+      detectSequence(tokenText, List(isBrace, isAt), 0, ignored).isDefined
     }
     else false
   }
 
-  /* Combines neighbouring regions based on some user provided criteria */
-  def explodeAdjacent[T, Repr <: Seq[ITypedRegion]](partitions: Repr)(exploder: (ITypedRegion, ITypedRegion, T) => Seq[ITypedRegion])(test: (ITypedRegion, ITypedRegion) => Option[T]): IndexedSeq[ITypedRegion] = {
-    val htmlPartitions = Set(TemplatePartitions.TEMPLATE_PLAIN, TemplatePartitions.TEMPLATE_TAG)
+  /* Combines neighbouring regions using `exploder` based on some user provided criteria, `test`. */
+  def explodeAdjacent[T](partitions: Seq[ITypedRegion])(exploder: (ITypedRegion, ITypedRegion, T) => Seq[ITypedRegion])(test: (ITypedRegion, ITypedRegion) => Option[T]): IndexedSeq[ITypedRegion] = {
     val accum = new ArrayBuffer[ITypedRegion]
     for (region <- partitions) {
-      if (accum.length == 0)
+      if (accum.isEmpty)
         accum += region
       else {
         val previousRegion = accum.last
@@ -81,12 +105,13 @@ object PartitionHelpers {
     accum
   }
 
-  private def merge(l: ITypedRegion, r: ITypedRegion, t: String) =
+  private def merge(l: ITypedRegion, r: ITypedRegion, t: String): List[TypedRegion] =
     List(new TypedRegion(l.getOffset, l.getLength + r.getLength, t))
+    
+  private val htmlPartitions: Set[String] = Set(TemplatePartitions.TEMPLATE_PLAIN, TemplatePartitions.TEMPLATE_TAG)
   
   /* Combines neighbouring regions that have the same type */
-  def mergeAdjacentWithSameType[Repr <: Seq[ITypedRegion]](partitions: Repr): IndexedSeq[ITypedRegion] = {
-    val htmlPartitions = Set(TemplatePartitions.TEMPLATE_PLAIN, TemplatePartitions.TEMPLATE_TAG)
+  def mergeAdjacentWithSameType(partitions: Seq[ITypedRegion]): IndexedSeq[ITypedRegion] = {
     explodeAdjacent(partitions)(merge) { (previousRegion, region) =>
       if (((htmlPartitions contains region.getType) && (htmlPartitions contains previousRegion.getType)) ||
          (region.getType == TemplatePartitions.TEMPLATE_SCALA && previousRegion.getType == TemplatePartitions.TEMPLATE_SCALA))
@@ -95,8 +120,8 @@ object PartitionHelpers {
     }
   }
 
-  /* Combine magic at with scala code partitions */
-  def combineMagicAt[Repr <: Seq[ITypedRegion]](partitions: Repr, codeString: String): IndexedSeq[ITypedRegion] = {
+  /* Combines "magic ats" with scala code partitions that directly follow it */
+  def combineMagicAt(partitions: Seq[ITypedRegion], codeString: String): IndexedSeq[ITypedRegion] = {
     explodeAdjacent(partitions)(merge) { (left, right) =>
       if ((isMagicAt(left, codeString) && right.getType() == TemplatePartitions.TEMPLATE_SCALA) ||
           (left.getType() == TemplatePartitions.TEMPLATE_SCALA && isMagicAt(right, codeString)))
@@ -105,20 +130,21 @@ object PartitionHelpers {
     }
   }
   
-  def separateBraceOrMagicAtFromEqual[Repr <: Seq[ITypedRegion]](partitions: Repr, codeString: String): IndexedSeq[ITypedRegion] = {
-    def explode(l: ITypedRegion, r: ITypedRegion, splitIndex: Int) = {
+  /** If there is a default partition token that matches the following psuedo-regex: (spaceOrTab?)('=')(spaceOrTab?)('{' || '@')(spaceOrTab?) then split the token into two somewhere in the middle white space area */
+  def separateBraceOrMagicAtFromEqual(partitions: Seq[ITypedRegion], codeString: String): IndexedSeq[ITypedRegion] = {
+    def explode(l: ITypedRegion, r: ITypedRegion, splitIndex: Int): Seq[ITypedRegion] = {
       val first = new TypedRegion(l.getOffset(), splitIndex - l.getOffset(), l.getType())
       val second = new TypedRegion(splitIndex, l.getLength() - first.getLength(), l.getType())
-      Array(first, second, r)
+      Seq(first, second, r)
     }
     
     explodeAdjacent(partitions)(explode) { (left, _) =>
       if (left.getType() == TemplatePartitions.TEMPLATE_DEFAULT) {
-        val code = codeString.substring(left.getOffset(), left.getOffset() + left.getLength())
-        def firstEqual = {c: Char => c == '='}
-        def secondBrace = {c: Char => c == '{' || c == '@'}
+        def code = textOf(left, codeString)
+        def isEquals = {c: Char => c == '='}
+        def isBraceOrAt = {c: Char => c == '{' || c == '@'}
         def ignored = {c: Char => c == ' ' || c == '\t'}
-        detectSequence(code, ListBuffer(firstEqual, secondBrace), 1, ignored) map (_ + left.getOffset())
+        detectSequence(code, List(isEquals, isBraceOrAt), 1, ignored) map (_ + left.getOffset())
       }
       else None
     }

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/lexical/TemplateRegionParser.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/lexical/TemplateRegionParser.scala
@@ -43,59 +43,36 @@ import org.eclipse.wst.xml.core.internal.parser.regions.RegionUpdateRule
 import org.eclipse.wst.sse.core.internal.util.Utilities
 import play.templates.ScalaTemplateParser
 import org.eclipse.jface.text.TypedRegion
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
-import org.eclipse.jface.text.Document
 import PartitionHelpers._
 import org.eclipse.jface.text.ITypedRegion
+import java.util.{ List => JList }
+import java.util.{ ArrayList => JArrayList }
+import org.eclipse.jdt.internal.core.util.SimpleDocument
 
 object TemplateDocumentRegions {
-  val SCALA_DOC_REGION = "SCALA_CONTENT"
-  val COMMENT_DOC_REGION = "TEMPLATE_COMMENT"
+  final val SCALA_DOC_REGION = "SCALA_CONTENT"
+  final val COMMENT_DOC_REGION = "TEMPLATE_COMMENT"
+  final val UNDEFINED = "UNDEFINED"
 }
 
 class TemplateRegionParser extends RegionParser with HasLogger {
-  
-  private class LazyCache[T](value: => T) {
-    
-    private var cache: Option[T] = None
 
-    def apply(): T = cache.getOrElse {
-      cache = Some(value)
-      cache.get
-    }
-    
-    def reset(): Unit = cache = None
-  }
-  
-  private var contents: String = ""
-  private val cachedRegions = new LazyCache(computeRegions(contents))
-  private val scalaTokeniserDocument = new org.eclipse.jface.text.Document("")
-  
-  /**
-   * RegionParser interface methods
-   */
-  override def newInstance() = new TemplateRegionParser
+  private[lexical] var templateRegions = new TemplateTextRegionsComputer("")
+  override def newInstance: RegionParser = new TemplateRegionParser
 
-  override def getDocumentRegions() = cachedRegions().head
+  override def getDocumentRegions(): IStructuredDocumentRegion = templateRegions.structuredRegions.head
 
   /* Get the full list of known regions */
-  override def getRegions(): java.util.List[ITextRegion] = {
-    import scala.collection.JavaConversions._
-    val resultList = new java.util.ArrayList[ITextRegion]()
-    cachedRegions().foreach(dr => {
-      for (textRegion: ITextRegion <- dr.getRegions().toArray) {
-        resultList.add(textRegion)
-      }
-    })
-    resultList
-  }
-  
+  override def getRegions(): JList[ITextRegion] = templateRegions.textRegions
+
   override def reset(input: String) =
     reset(new StringReader(input))
-  
+
   override def reset(input: String, offset: Int) =
     reset(new StringReader(input), offset)
-  
+
   override def reset(reader: Reader) = reset(reader, 0)
 
   override def reset(reader: Reader, offset: Int) = {
@@ -105,377 +82,433 @@ class TemplateRegionParser extends RegionParser with HasLogger {
       sb.append(c.toChar)
       c = reader.read()
     }
-    contents = sb.toString()
-    cachedRegions.reset()
+    templateRegions = new TemplateTextRegionsComputer(sb.toString())
   }
-  
-  def computeRegions(codeString: String): Array[IStructuredDocumentRegion] = {
-    
-    def buildDocRegionMap(headRegion: IStructuredDocumentRegion): collection.Map[Int, IStructuredDocumentRegion] = {
-      val map = new HashMap[Int, IStructuredDocumentRegion]
-      map.sizeHint(codeString.length / 50) // just a gut feeling that doc regions average around 50 characters in size
-      var current = headRegion
-      while (current != null) {
-        for (i <- current.getStart() to (current.getEnd() - 1))
-          map(i) = current
-        current = current.getNext()
-      }
-      map
-    }
-    
-    def getNumberOfDocumentRegions(headRegion: IStructuredDocumentRegion) = {
-      @tailrec
-      def aux(region: IStructuredDocumentRegion, count: Int): Int = {
-        if (region == null) count
-        else aux(region.getNext(), count + 1)
-      }
-      aux(headRegion, 0)
-    }
-    
-    // This is a copy and pasted implementation of AttributeNameRegion, with the only change being that adjustTextLength
-    // actually adds the parameter to the field :). Had to reimplement the whole class because the fields in AttributeNameRegion are private
-    class FixedAttributeNameRegion(start: Int, textLength: Int, length: Int) extends AttributeNameRegion(start, textLength, length) { 
-      private var fLength: Int = length
-      private var fStart: Int = start
-      private var fTextLength: Int = textLength
+}
 
-      override def adjustLength(i: Int) { fLength += i }
-      override def adjustStart(i: Int) { fStart += i }
-      override def adjustTextLength(i: Int) { fTextLength += i } // this is the only thing that's changed!!
-      override def equatePositions(region: ITextRegion) {
-        fStart = region.getStart
-        fLength = region.getLength
-        fTextLength = region.getTextLength
+class TemplateTextRegionsComputer(documentContent: String) extends HasLogger {
+
+  /**
+   * The tokens for this `documentContent`.
+   *
+   *  @note The standard Play Template parser doesn't tokenize the `documentContent` in exactly the way we expect it.
+   *        Hence, here we are mapping the tokens returned by the Play Template parse into the ones that fits our needs.
+   */
+  private lazy val tokens: Seq[ITypedRegion] = {
+    val tokenizer = new TemplatePartitionTokeniser
+    val originalTokens = tokenizer.tokenise(documentContent)
+    separateBraceOrMagicAtFromEqual(originalTokens, documentContent)
+  }
+
+  /** Returns the `IStructuredDocumentRegion`s for this `documentContent`. */
+  private[lexical] val structuredRegions: Array[IStructuredDocumentRegion] = {
+    val resultRegions: IStructuredDocumentRegion = htmlHeadRegion match {
+      // The html parser returns null on empty input..
+      case None => {
+        val region = new BasicStructuredDocumentRegion
+        region.setStart(0)
+        region.setLength(documentContent.length())
+        region.addRegion(new ContextRegion(TemplateDocumentRegions.UNDEFINED, 0, documentContent.length(), documentContent.length()))
+        region
       }
-      override def getEnd(): Int = fStart + fLength
-      override def getLength(): Int = fLength
-      override def getStart(): Int = fStart
-      override def getTextEnd(): Int = fStart + fTextLength
-      override def getTextLength(): Int = fTextLength
-      override def updateRegion(requester: AnyRef, 
-          parent: IStructuredDocumentRegion, 
-          changes: String, 
-          requestStart: Int, 
-          lengthToReplace: Int): StructuredDocumentEvent = {
-        var result: RegionChangedEvent = null
-        if (Debug.debugStructuredDocument) {
-          println("\t\tContextRegion::updateModel")
-          println("\t\t\tregion type is " + getType())
-        }
-        var canHandle = false
-        canHandle = if ((changes == null) || (changes.length == 0)) if ((fStart >= getTextEnd) || 
-          (Math.abs(lengthToReplace) >= getTextEnd - getStart)) false else true else if ((RegionUpdateRule.canHandleAsWhiteSpace(this, 
-          parent, changes, requestStart, lengthToReplace)) || 
-          RegionUpdateRule.canHandleAsLetterOrDigit(this, parent, changes, requestStart, lengthToReplace)) true else false
-        if (canHandle) {
-          if (Debug.debugStructuredDocument) {
-            println("change handled by region")
+      case Some(htmlHead) => {
+        // The purpose of the headSentinal is so that if there is only one actual html document region,
+        // and that html document region eventually becomes wholly replaced by `replaceDocumentRegionsWithTemplateTextRegions`
+        // then we don't need handle that specially (meaning: without this sentinal, `replaceDocumentRegionsWithTemplateTextRegions` wouldn't have any
+        // previous or after nodes to insert the new doc region into, so we'd lose the reference to it, effectively making `replaceDocumentRegionsWithTemplateTextRegions`
+        // appear to be a no-op.)
+        val headSentinal = new BasicStructuredDocumentRegion
+        headSentinal.setNext(htmlHead)
+        htmlHead.setPrevious(headSentinal)
+
+        // merge '@' tokens with scala code tokens, and then merge any adjacent tokens of the same type.
+        // Merging here has the affect of not having neighbouring document regions of the same type
+        // Note: it is necessary to merge the '@' with scala code, because otherwise during the `mergeAdjacentWithSameType`
+        // pass, the '@' will be merged with random default partition tokens, thus making it much harder to later find the '@'
+        // and properly syntax hightlight it.
+        val mergedTokens = mergeAdjacentWithSameType(combineMagicAt(tokens, documentContent))
+        val token2template = new TemplateTextRegionConverter(documentContent, tokens)
+        for {
+          token <- mergedTokens
+          if !isHtmlToken(token)
+        } {
+          val (templateTextRegions: Seq[TemplateTextRegion], scalaDocType: String) = token2template(token)
+          // If there are scala text regions, insert them into the HTML document regions
+          if (templateTextRegions.nonEmpty) {
+            // absolute offsets
+            val (startEffectedOffset, endEffectedOffset) = (token.getOffset(), token.getOffset() + token.getLength())
+            (htmlHead.regionMap.get(startEffectedOffset), htmlHead.regionMap.get(endEffectedOffset - 1)) match {
+              case (Some(startEffectedDocumentRegion), Some(endEffectedDocumentRegion)) => {
+                // If the scala text regions spans exactly the same space as the document regions it overlaps,
+                // Then replace those document regions with our own document regions
+                if (startEffectedDocumentRegion.getStart() == startEffectedOffset && endEffectedDocumentRegion.getEnd() == endEffectedOffset)
+                  replaceDocumentRegionsWithTemplateTextRegions(startEffectedDocumentRegion, endEffectedDocumentRegion, scalaDocType, templateTextRegions)
+                else {
+                  // handle the cases where we need to trim text regions and then insert our text regions into (a) html document region(s)
+                  if (startEffectedDocumentRegion == endEffectedDocumentRegion)
+                    insertScalaRegions(startEffectedDocumentRegion, templateTextRegions, startEffectedOffset, endEffectedOffset)
+                  else
+                    insertScalaRegionsOverMultipleDocRegions(token.getOffset(), templateTextRegions, startEffectedDocumentRegion, startEffectedOffset, endEffectedDocumentRegion, endEffectedOffset)
+                }
+              }
+
+              case _ => logger.debug("TemplateRegionParser: startEffectedDocumentRegion or endEffectedDocumentRegion could not be found.")
+            }
           }
-          val lengthDifference = Utilities.calculateLengthDifference(changes, lengthToReplace)
-          if (!RegionUpdateRule.canHandleAsWhiteSpace(this, parent, changes, requestStart, lengthToReplace)) {
-            fTextLength += lengthDifference
-          }
-          fLength += lengthDifference
-          result = new RegionChangedEvent(parent.getParentDocument, requester, parent, this, changes, requestStart, 
-            lengthToReplace)
         }
-        result
+
+        headSentinal.getNext()
       }
     }
 
-    def copyXMLTextRegion(region: ITextRegion): ITextRegion = region match {
-      case attribEquals: AttributeEqualsRegion => new AttributeEqualsRegion(attribEquals.getStart(), attribEquals.getTextLength(), attribEquals.getLength())
-      case attribName: AttributeNameRegion => new FixedAttributeNameRegion(attribName.getStart(), attribName.getTextLength(), attribName.getLength())
-      case attribValue: AttributeValueRegion => new AttributeValueRegion(attribValue.getStart(), attribValue.getTextLength(), attribValue.getLength())
-      case emptyTagClose: EmptyTagCloseRegion => new EmptyTagCloseRegion(emptyTagClose.getStart(), emptyTagClose.getTextLength(), emptyTagClose.getLength())
-      case endTagOpen: EndTagOpenRegion => new EndTagOpenRegion(endTagOpen.getStart(), endTagOpen.getTextLength(), endTagOpen.getLength())
-      case tagClose: TagCloseRegion => new TagCloseRegion(tagClose.getStart())
-      case tagName: TagNameRegion => new TagNameRegion(tagName.getStart(), tagName.getTextLength(), tagName.getLength())
-      case tagOpen: TagOpenRegion => new TagOpenRegion(tagOpen.getStart(), tagOpen.getTextLength(), tagOpen.getLength())
-      case whitespace: WhiteSpaceOnlyRegion => new WhiteSpaceOnlyRegion(whitespace.getStart(), whitespace.getLength())
-      case cdata: XMLCDataTextRegion => new XMLCDataTextRegion(cdata.getStart(), cdata.getTextLength(), cdata.getLength())
-      case content: XMLContentRegion => new XMLContentRegion(content.getStart(), content.getLength())
-      case context: ContextRegion => new ContextRegion(context.getType(), context.getStart(), context.getTextLength(), context.getLength())
-      case _ => {
-        logger.error(s"TemplateRegionParser: Unhandled attempt to copy XML region: $region")
-        null
-      }
+    val ab = new ArrayBuffer[IStructuredDocumentRegion]
+    var current = resultRegions
+    while (current != null) {
+      ab += current
+      current = current.getNext()
     }
-    
+
+    ab.toArray
+  }
+
+  /** Returns the `ITextRegion`s for this `documentContent`. */
+  lazy val textRegions: JList[ITextRegion] = {
+    val resultList = new JArrayList[ITextRegion]()
+    structuredRegions.foreach(dr => {
+      for (textRegion: ITextRegion <- dr.getRegions().toArray) {
+        resultList.add(textRegion)
+      }
+    })
+    resultList
+  }
+
+  private lazy val htmlHeadRegion: Option[RichStructuredDocumentRegion] = {
     // The block regions enable javascript and css support, as BLOCK_TEXT regions are treated special by the html component
     import org.eclipse.wst.xml.core.internal.regions.DOMRegionContext
     import org.eclipse.wst.sse.core.internal.ltk.parser.BlockMarker
     val htmlParser = new XMLSourceParser
     htmlParser.addBlockMarker(new BlockMarker("script", null, DOMRegionContext.BLOCK_TEXT, false))
     htmlParser.addBlockMarker(new BlockMarker("style", null, DOMRegionContext.BLOCK_TEXT, false))
-    htmlParser.reset(codeString)
-    val htmlDocumentRegions = htmlParser.getDocumentRegions()
-    lazy val htmlDocumentRegionsMap = buildDocRegionMap(htmlDocumentRegions)
-    lazy val htmlDocumentRegionsLength = getNumberOfDocumentRegions(htmlDocumentRegions)
-    var resultRegions = htmlDocumentRegions
-    
-    // tokenise, merge '@' tokens with scala code tokens, and then merge any adjacent tokens of the same type.
-    // Merging here has the affect of not having neighbouring document regions of the same type
-    val tokens = separateBraceOrMagicAtFromEqual(TemplatePartitionTokeniser.tokenise(codeString), codeString).toVector
-    val tokenIndexLookup = new collection.mutable.HashMap[Int, ITypedRegion]
-    tokenIndexLookup.sizeHint(tokens.length)
-    for (reg <- tokens) {
-      val kv = (reg.getOffset(), reg)
-      tokenIndexLookup += kv
+    htmlParser.reset(documentContent)
+    Option(htmlParser.getDocumentRegions()) map (new RichStructuredDocumentRegion(_))
+  }
+
+  private def isHtmlToken(token: ITypedRegion): Boolean = {
+    token.getType() == TemplatePartitions.TEMPLATE_PLAIN ||
+      token.getType() == TemplatePartitions.TEMPLATE_TAG ||
+      (token.getType() == TemplatePartitions.TEMPLATE_DEFAULT && !PartitionHelpers.isBrace(token, documentContent) && !PartitionHelpers.isCombinedBraceMagicAt(token, documentContent))
+  }
+
+  private def replaceDocumentRegionsWithTemplateTextRegions(leftReplacedDocumentRegion: IStructuredDocumentRegion, rightReplacedDocumentRegion: IStructuredDocumentRegion, templateDocType: String, templateTextRegions: Seq[TemplateTextRegion]): IStructuredDocumentRegion = {
+    val startEffectedOffset = leftReplacedDocumentRegion.getStart()
+    val endEffectedOffset = rightReplacedDocumentRegion.getEnd()
+    val region = new BasicStructuredDocumentRegion { override def getType() = templateDocType }
+    region.setStart(startEffectedOffset)
+    region.setLength(endEffectedOffset - startEffectedOffset)
+    templateTextRegions.foreach(region.addRegion(_))
+    // insert our new region where the effected regions were
+    Option(leftReplacedDocumentRegion.getPrevious()).foreach { previous =>
+      previous.setNext(region)
+      region.setPrevious(previous)
+    }
+    Option(rightReplacedDocumentRegion.getNext()) match {
+      case Some(next) =>
+        next.setPrevious(region)
+        region.setNext(next)
+      case None => region.setEnded(true)
+    }
+    region
+  }
+
+  private[lexical] implicit def richStructuredDocumentRegion2structuredDocumentRegion(doc: RichStructuredDocumentRegion): IStructuredDocumentRegion = doc.region
+  private[lexical] class RichStructuredDocumentRegion(val region: IStructuredDocumentRegion) {
+    assert(region != null)
+
+    /* Maps document offsets to document regions */
+    lazy val regionMap: collection.Map[Int, IStructuredDocumentRegion] = {
+      @tailrec
+      def aux(current: IStructuredDocumentRegion, result: Map[Int, IStructuredDocumentRegion]): Map[Int, IStructuredDocumentRegion] = current match {
+        case null => result
+        case _ =>
+          val offsets = current.getStart() until current.getEnd()
+          aux(current.getNext(), result ++ (offsets map ((_, current))))
+      }
+      aux(region, Map())
     }
 
-    val mergedTokens = mergeAdjacentWithSameType(combineMagicAt(tokens, codeString)).toArray
-    val dummyDoc = new Document(codeString)
-    for (token <- mergedTokens) {
-      val representsHTML =
-        (token.getType() == TemplatePartitions.TEMPLATE_PLAIN ||
-         token.getType() == TemplatePartitions.TEMPLATE_TAG   ||
-         (token.getType() == TemplatePartitions.TEMPLATE_DEFAULT && !PartitionHelpers.isBrace(token, codeString) && !PartitionHelpers.isCombinedBraceMagicAt(token, codeString)))
-      if (!representsHTML) {
-        val (templateTextRegions: Seq[ScalaTextRegion], scalaDocType: String) = {
-          if (token.getType == TemplatePartitions.TEMPLATE_SCALA) {
-            val regions = new ListBuffer[ScalaTextRegion]
-            var currentIndex = token.getOffset()
-            while (currentIndex < (token.getOffset() + token.getLength())) {
-              val t = tokenIndexLookup(currentIndex)
-              if (PartitionHelpers.isMagicAt(t, codeString)) {
-                regions += new ScalaTextRegion(TemplateSyntaxClasses.MAGIC_AT, t.getOffset() - token.getOffset(), t.getLength(), t.getLength())
-              } // actual scala code
-              else { //if (t.getType() == TemplatePartitions.TEMPLATE_SCALA) {
-                // TODO - figure out a good way to get the prefstore from the editor
-                val prefStore = new ChainedPreferenceStore(Array((EditorsUI.getPreferenceStore()), PlayPlugin.preferenceStore))
-                val scanner = new ScalaCodeScanner(prefStore, ScalaVersions.Scala_2_10)
-                val tokens = scanner.tokenize(dummyDoc, t.getOffset(), t.getLength())
-                tokens.foreach{ v =>
-                  regions += new ScalaTextRegion(v.syntaxClass, v.start - token.getOffset(), v.length, v.length)
-                }
-              }
-              currentIndex += t.getLength()
-            } 
-            
-            (regions, TemplateDocumentRegions.SCALA_DOC_REGION)
-          }
-          else if (PartitionHelpers.isBrace(token, codeString))
-            (List(new ScalaTextRegion(TemplateSyntaxClasses.BRACE, 0, token.getLength(), token.getLength())), TemplateDocumentRegions.SCALA_DOC_REGION)
-          else if (token.getType == TemplatePartitions.TEMPLATE_COMMENT)
-            (List(new ScalaTextRegion(TemplateSyntaxClasses.COMMENT, 0, token.getLength(), token.getLength())), TemplateDocumentRegions.COMMENT_DOC_REGION)
-          else if (PartitionHelpers.isCombinedBraceMagicAt(token, codeString)) {
-            val splitIndex = codeString.indexWhere({c: Char => (c == '}' || c == '{')}, token.getOffset())
-            val braceLen = splitIndex - token.getOffset()
-            val magicAtLen = token.getLength() - braceLen
-            val brace = new ScalaTextRegion(TemplateSyntaxClasses.BRACE, 0, braceLen, braceLen)
-            val magicAt = new ScalaTextRegion(TemplateSyntaxClasses.MAGIC_AT, braceLen, magicAtLen, magicAtLen)
-            (List(brace, magicAt), TemplateDocumentRegions.SCALA_DOC_REGION)
-          }
-          else (List(), "UNDEFINED")
+    /* How many structured regions are in linked list that this region is the head of? */
+    lazy val regionCount = {
+      @tailrec
+      def aux(region: IStructuredDocumentRegion, count: Int): Int = {
+        if (region == null) count
+        else aux(region.getNext(), count + 1)
+      }
+      aux(region, 0)
+    }
+  }
+
+  private def insertScalaRegions(effectedDocRegion: IStructuredDocumentRegion, templateTextRegions: Seq[TemplateTextRegion], startEffectedOffset: Int, endEffectedOffset: Int) = {
+    val textRegions = effectedDocRegion.getRegions().toArray // "textregionlist to java array to scala array
+    val leftTextRegion = effectedDocRegion.getRegionAtCharacterOffset(startEffectedOffset)
+    val rightTextRegion = effectedDocRegion.getRegionAtCharacterOffset(endEffectedOffset - 1) // end offsets are not inclusive
+
+    // add text regions up to leftTextRegion
+    val regionsBefore = textRegions.takeWhile(_ != leftTextRegion)
+
+    // split left text region if necessary
+    val leftSplit = (effectedDocRegion.getStartOffset(leftTextRegion) < startEffectedOffset) match {
+      case true => {
+        val split = copyXMLTextRegion(leftTextRegion)
+        val adjustment = -(effectedDocRegion.getEndOffset(leftTextRegion) - startEffectedOffset)
+        split.adjustLength(adjustment)
+        split.adjustTextLength(adjustment)
+        Some(split)
+      }
+      case false => None
+    }
+
+    // add template text regions
+    val middleTemplateRegions = {
+      var currentTemplateOffset = startEffectedOffset - effectedDocRegion.getStart()
+      for (tr <- templateTextRegions) yield {
+        tr.setStart(currentTemplateOffset)
+        currentTemplateOffset += tr.getLength()
+        tr
+      }
+    }
+
+    // split right text region if necessary
+    val rightSplit = (effectedDocRegion.getEndOffset(rightTextRegion) > endEffectedOffset) match {
+      case true => {
+        val split = copyXMLTextRegion(rightTextRegion)
+        val adjustment = endEffectedOffset - effectedDocRegion.getStartOffset(rightTextRegion)
+        split.adjustStart(adjustment)
+        split.adjustLength(-adjustment)
+        split.adjustTextLength(-adjustment)
+        Some(split)
+      }
+      case false => None
+    }
+
+    // add text regions after right text region until end
+    val regionsAfter = textRegions.filter(_.getStart() > rightTextRegion.getStart())
+
+    // replace the doc's text regions with the new text regions
+    val newTextRegions = regionsBefore ++ leftSplit ++ middleTemplateRegions ++ rightSplit ++ regionsAfter
+    val newTextRegionList = new TextRegionListImpl
+    for (tr <- newTextRegions)
+      newTextRegionList.add(tr)
+    effectedDocRegion.setRegions(newTextRegionList)
+  }
+
+  private def copyXMLTextRegion(region: ITextRegion): ITextRegion = region match {
+    case attribEquals: AttributeEqualsRegion => new AttributeEqualsRegion(attribEquals.getStart(), attribEquals.getTextLength(), attribEquals.getLength())
+    case attribName: AttributeNameRegion     => new FixedAttributeNameRegion(attribName.getStart(), attribName.getTextLength(), attribName.getLength())
+    case attribValue: AttributeValueRegion   => new AttributeValueRegion(attribValue.getStart(), attribValue.getTextLength(), attribValue.getLength())
+    case emptyTagClose: EmptyTagCloseRegion  => new EmptyTagCloseRegion(emptyTagClose.getStart(), emptyTagClose.getTextLength(), emptyTagClose.getLength())
+    case endTagOpen: EndTagOpenRegion        => new EndTagOpenRegion(endTagOpen.getStart(), endTagOpen.getTextLength(), endTagOpen.getLength())
+    case tagClose: TagCloseRegion            => new TagCloseRegion(tagClose.getStart())
+    case tagName: TagNameRegion              => new TagNameRegion(tagName.getStart(), tagName.getTextLength(), tagName.getLength())
+    case tagOpen: TagOpenRegion              => new TagOpenRegion(tagOpen.getStart(), tagOpen.getTextLength(), tagOpen.getLength())
+    case whitespace: WhiteSpaceOnlyRegion    => new WhiteSpaceOnlyRegion(whitespace.getStart(), whitespace.getLength())
+    case cdata: XMLCDataTextRegion           => new XMLCDataTextRegion(cdata.getStart(), cdata.getTextLength(), cdata.getLength())
+    case content: XMLContentRegion           => new XMLContentRegion(content.getStart(), content.getLength())
+    case context: ContextRegion              => new ContextRegion(context.getType(), context.getStart(), context.getTextLength(), context.getLength())
+    case _ => {
+      logger.error(s"TemplateRegionParser: Unhandled attempt to copy XML region: $region")
+      null
+    }
+  }
+
+  private def insertScalaRegionsOverMultipleDocRegions(globalTokenOffset: Int, templateTextRegions: Seq[TemplateTextRegion], startEffectedDocumentRegion: IStructuredDocumentRegion, startEffectedOffset: Int, endEffectedDocumentRegion: IStructuredDocumentRegion, endEffectedOffset: Int) = {
+    // Get a list of all effected document regions, plus their corresponding start and end effected offsets
+    //   (which will correspond exactly to the document's start and end for the non-head and non-tail elements.
+    val effectedDocuments: ListBuffer[(IStructuredDocumentRegion, Int, Int)] = overlappedDocumentRegions(startEffectedDocumentRegion, endEffectedDocumentRegion, startEffectedOffset, endEffectedOffset, true)
+    var currentTextRegion = 0
+    val scalaRegions: ArrayBuffer[TemplateTextRegion] = ArrayBuffer()
+    for ((effectedDocRegion, startEffectedOffset, endEffectedOffset) <- effectedDocuments) {
+      def globalOffset(offset: Int) = globalTokenOffset + offset
+      def copyScalaRegion(tr: TemplateTextRegion, newStart: Option[Int] = None, newLength: Option[Int] = None): TemplateTextRegion = {
+        val trcopy = tr.copy()
+        newStart.foreach(trcopy.setStart(_))
+        newLength.foreach(trcopy.setLength(_))
+        trcopy
+      }
+
+      var done = false
+      while (!done && currentTextRegion < templateTextRegions.length) {
+        val tr = templateTextRegions(currentTextRegion)
+        val trGlobalStart = globalOffset(tr.getStart())
+        val trGlobalEnd = globalOffset(tr.getEnd())
+
+        val contained = trGlobalStart >= startEffectedOffset && trGlobalEnd <= endEffectedOffset
+        val leftOverlap = trGlobalStart < startEffectedOffset && trGlobalEnd <= endEffectedOffset
+        val rightOverlap = trGlobalStart >= startEffectedOffset && trGlobalStart < endEffectedOffset && trGlobalEnd > endEffectedOffset
+        val overspan = trGlobalStart <= startEffectedOffset && trGlobalEnd >= endEffectedOffset
+
+        // the scala text region is fully within the doc region
+        if (contained) {
+          scalaRegions += tr
+          currentTextRegion += 1
+        } // the scala text region overlaps the left hand side of the doc region
+        else if (leftOverlap) {
+          scalaRegions += copyScalaRegion(tr, Some(startEffectedOffset - effectedDocRegion.getStart()), Some(tr.getLength() - (startEffectedOffset - trGlobalStart)))
+          currentTextRegion += 1
+        } // the scala text region overlaps the right hand side of the doc region
+        else if (rightOverlap) {
+          scalaRegions += copyScalaRegion(tr, newLength = Some(tr.getLength() - (trGlobalEnd - endEffectedOffset)))
+          // don't increment currentTextRegion because it might also be used by the next structured document
+        } // the scala text region fully encompasses the doc region 
+        else if (overspan) {
+          scalaRegions += copyScalaRegion(tr, Some(0), Some(effectedDocRegion.getLength()))
+          // don't increment currentTextRegion because it might also be used by the next structured document
         }
-        
-        if (templateTextRegions.nonEmpty) {
-          // absolute offsets
-          val (startEffectedOffset, endEffectedOffset) = (token.getOffset(), token.getOffset() + token.getLength())
-          val startEffectedDocumentRegionOpt = htmlDocumentRegionsMap.get(startEffectedOffset)
-          val endEffectedDocumentRegionOpt = htmlDocumentRegionsMap.get(endEffectedOffset - 1)
-          
-          (startEffectedDocumentRegionOpt, endEffectedDocumentRegionOpt) match {
-            case (Some(startEffectedDocumentRegion), Some(endEffectedDocumentRegion)) => {
-              // If the scala text regions spans exactly the same space as the document regions it overlaps
-              // Then replace those document regions with our own document regions
-              if (startEffectedDocumentRegion.getStart() == startEffectedOffset && endEffectedDocumentRegion.getEnd() == endEffectedOffset) {
-                val region = new BasicStructuredDocumentRegion { override def getType() = scalaDocType }
-                region.setStart(startEffectedOffset)
-                region.setLength(token.getLength())
-                templateTextRegions.foreach(region.addRegion(_))
-                
-                if (htmlDocumentRegionsLength == 1) {
-                  resultRegions = region
-                }
-                else {
-                  // insert our new region where the effected regions were
-                  Option(startEffectedDocumentRegion.getPrevious()).foreach { previous =>
-                    previous.setNext(region)
-                    region.setPrevious(previous)
-                  }
-                  Option(endEffectedDocumentRegion.getNext()) match {
-                    case Some(next) => {
-                      next.setPrevious(region)
-                      region.setNext(next)
-                    }
-                    case None => region.setEnded(true)
-                  }
-                }
-              }
-              else {
-                def insertScalaRegions(effectedDocRegion: IStructuredDocumentRegion, templateTextRegions: Seq[ScalaTextRegion], startEffectedOffset: Int, endEffectedOffset: Int) = {
-                  val textRegions = effectedDocRegion.getRegions().toArray().toArray // "textregionlist to java array to scala array
-                  val leftTextRegion = effectedDocRegion.getRegionAtCharacterOffset(startEffectedOffset)
-                  val rightTextRegion = effectedDocRegion.getRegionAtCharacterOffset(endEffectedOffset - 1) // end offsets are not inclusive
-                  val newTextRegions = new ArrayBuffer[ITextRegion]
-                  
-                  // add text regions up to leftTextRegion
-                  var i = 0
-                  while (textRegions(i) != leftTextRegion) {
-                    newTextRegions += textRegions(i)
-                    i += 1
-                  }
-                  
-                  // split left text region if necessary
-                  if (effectedDocRegion.getStartOffset(leftTextRegion) < startEffectedOffset) {
-                    val leftSplit = copyXMLTextRegion(leftTextRegion)
-                    val adjustment = -(effectedDocRegion.getEndOffset(leftTextRegion) - startEffectedOffset)
-                    leftSplit.adjustLength(adjustment)
-                    leftSplit.adjustTextLength(adjustment)
-                    newTextRegions += leftSplit
-                  }
-                  
-                  // add template text regions
-                  var currentTemplateOffset = startEffectedOffset - effectedDocRegion.getStart()
-                  for (tr <- templateTextRegions) {
-                    tr.setStart(currentTemplateOffset)
-                    newTextRegions += tr
-                    currentTemplateOffset += tr.getLength()
-                  }
-                  
-                  // split right text region if necessary
-                  if (effectedDocRegion.getEndOffset(rightTextRegion) > endEffectedOffset) {
-                    val rightSplit = copyXMLTextRegion(rightTextRegion)
-                    val adjustment = endEffectedOffset - effectedDocRegion.getStartOffset(rightTextRegion)
-                    rightSplit.adjustStart(adjustment)
-                    rightSplit.adjustLength(-adjustment)
-                    rightSplit.adjustTextLength(-adjustment)
-                    newTextRegions += rightSplit
-                  }
-                  
-                  // add text regions after right text region until end
-                  i = 0
-                  while (i < textRegions.length) {
-                    val tr = textRegions(i)
-                    if (tr.getStart() > rightTextRegion.getStart()) {
-                      newTextRegions += tr
-                    }
-                    i += 1
-                  }
-                  
-                  // replace the doc's text regions with the new text regions
-                  val newTextRegionList = new TextRegionListImpl
-                  for (tr <- newTextRegions) 
-                    newTextRegionList.add(tr)
-                  effectedDocRegion.setRegions(newTextRegionList)
-                }
-                
-                // handle the case where we need to trim text regions and then insert our text regions
-                // Note: this code does not try to handle scala code that spans two (or more) xml document regions
-                if (startEffectedDocumentRegion == endEffectedDocumentRegion) {
-                  val effectedDocRegion = startEffectedDocumentRegion
-                  insertScalaRegions(effectedDocRegion, templateTextRegions, startEffectedOffset, endEffectedOffset)
-                }
-                else {
-                  // Get a list of all effected document regions, plus their corresponding start and end effected offsets
-                  //   (which will correspond exactly to the document's start and end for the non-head and non-tail elements.
-                  var effectedDocuments: ListBuffer[(IStructuredDocumentRegion, Int, Int)] = {
-                     val result: ListBuffer[(IStructuredDocumentRegion, Int, Int)] = ListBuffer((startEffectedDocumentRegion, startEffectedOffset, startEffectedDocumentRegion.getEnd()))
-                     var doc = startEffectedDocumentRegion.getNext()
-                     while (doc != endEffectedDocumentRegion) {
-                       doc = doc.getNext()
-                       if (doc != endEffectedDocumentRegion)
-                         result += ((doc, doc.getStart(), doc.getEnd()))
-                     } 
-                     result += ((endEffectedDocumentRegion, endEffectedDocumentRegion.getStart(), endEffectedOffset))
-                     
-                     // there can be gaps.. so create new doc regions for the gaps
-                     for (i <- 0 to (result.length - 2)) {
-                       val ((l, lstart, lend), (r, rstart, _)) = result(i) -> result(i+1)
-                       if (lend != rstart) {
-                         val newRegion = new BasicStructuredDocumentRegion
-                         newRegion.addRegion(new ContextRegion("UNDEFINED", 0, rstart - lend, rstart - lend))
-                         newRegion.setStart(lend)
-                         newRegion.setLength(rstart - lend)
-                         l.setNext(newRegion)
-                         newRegion.setPrevious(l)
-                         newRegion.setNext(r)
-                         r.setPrevious(newRegion)
-                         result.insert(i+1, (newRegion, lend, rstart))
-                       }
-                     }
-                     
-                     result
-                   }
-                  
-                  var currentTextRegion = 0 
-                  val scalaRegions: ArrayBuffer[ScalaTextRegion] = ArrayBuffer()
-                  for ((effectedDocRegion, startEffectedOffset, endEffectedOffset) <- effectedDocuments) {
-                    def globalOffset(offset: Int) = token.getOffset() + offset
-                    
-                    var done = false
-                    while (!done && currentTextRegion < templateTextRegions.length) {
-                      val tr = templateTextRegions(currentTextRegion)
-                      val trGlobalStart = globalOffset(tr.getStart())
-                      val trGlobalEnd = globalOffset(tr.getEnd())
-                      
-                      val contained = trGlobalStart >= startEffectedOffset && trGlobalEnd <= endEffectedOffset
-                      val leftOverlap = trGlobalStart < startEffectedOffset && trGlobalEnd <= endEffectedOffset
-                      val rightOverlap = trGlobalStart >= startEffectedOffset && trGlobalStart < endEffectedOffset && trGlobalEnd > endEffectedOffset
-                      val overspan = trGlobalStart <= startEffectedOffset && trGlobalEnd >= endEffectedOffset
-                      
-                      // the scala text region is fully within the doc region
-                      if (contained) {
-                        scalaRegions += tr
-                        currentTextRegion += 1
-                      }
-                      // the scala text region overlaps the left hand side of the doc region
-                      else if (leftOverlap) {
-                        val trcopy = tr.copy()
-                        trcopy.setStart(startEffectedOffset - effectedDocRegion.getStart())
-                        trcopy.setLength(trcopy.getLength() - (startEffectedOffset - trGlobalStart))
-                        scalaRegions += trcopy
-                        currentTextRegion += 1
-                      }
-                      // the scala text region overlaps the right hand side of the doc region
-                      else if (rightOverlap) {
-                        val trcopy = tr.copy()
-                        trcopy.setLength(trcopy.getLength() - (trGlobalEnd - endEffectedOffset))
-                        scalaRegions += trcopy
-                        // don't increment currentTextRegion because it might also be used by the next structured document
-                      }
-                      // the scala text region fully encompasses the doc region 
-                      else if (overspan) {
-                        val trcopy = tr.copy()
-                        trcopy.setStart(0)
-                        trcopy.setLength(effectedDocRegion.getLength())
-                        scalaRegions += tr.copy()
-                        // don't increment currentTextRegion because it might also be used by the next structured document
-                      }
-                      
-                      done = overspan || rightOverlap || (trGlobalStart >= endEffectedOffset)
-                    }
-                    
-                    insertScalaRegions(effectedDocRegion, scalaRegions, startEffectedOffset, endEffectedOffset)
-                    scalaRegions.clear()
-                  }
-                }
-              }
-            }
-            
-            case _ => logger.debug("TemplateRegionParser: startEffectedDocumentRegion or endEffectedDocumentRegion could not be found.")
-          }
+
+        done = overspan || rightOverlap || (trGlobalStart >= endEffectedOffset)
+      }
+
+      insertScalaRegions(effectedDocRegion, scalaRegions, startEffectedOffset, endEffectedOffset)
+      scalaRegions.clear()
+    }
+  }
+
+  private def overlappedDocumentRegions(leftBound: IStructuredDocumentRegion, rightBound: IStructuredDocumentRegion, startOffset: Int, endOffset: Int, fillGaps: Boolean): ListBuffer[(IStructuredDocumentRegion, Int, Int)] = {
+    val result: ListBuffer[(IStructuredDocumentRegion, Int, Int)] = ListBuffer((leftBound, startOffset, leftBound.getEnd()))
+    var doc = leftBound.getNext()
+    while (doc != rightBound) {
+      doc = doc.getNext()
+      if (doc != rightBound)
+        result += ((doc, doc.getStart(), doc.getEnd()))
+    }
+    result += ((rightBound, rightBound.getStart(), endOffset))
+
+    // there can be gaps.. so create new doc regions for the gaps
+    if (fillGaps) {
+      for (i <- 0 to (result.length - 2)) {
+        val ((l, lstart, lend), (r, rstart, _)) = result(i) -> result(i + 1)
+        if (lend != rstart) {
+          val newRegion = new BasicStructuredDocumentRegion
+          newRegion.addRegion(new ContextRegion("UNDEFINED", 0, rstart - lend, rstart - lend))
+          newRegion.setStart(lend)
+          newRegion.setLength(rstart - lend)
+          l.setNext(newRegion)
+          newRegion.setPrevious(l)
+          newRegion.setNext(r)
+          r.setPrevious(newRegion)
+          result.insert(i + 1, (newRegion, lend, rstart))
         }
       }
     }
 
-    // The html parser returns null on empty input.. Talk about handling corner cases :P
-    if (resultRegions == null) {
-      resultRegions = new BasicStructuredDocumentRegion
-      resultRegions.setStart(0)
-      resultRegions.setLength(codeString.length())
-      resultRegions.addRegion(new ContextRegion("UNDEFINED", 0, codeString.length(), codeString.length()))
+    result
+  }
+}
+
+/**
+ * Converts the passed `tokens` into `TemplateTextRegion`.
+ * 
+ * This class is not thread-safe.
+ *
+ *  @param documentContent The document's content.
+ *  @param tokens The `tokens` for the passed `documentContent`.
+ */
+private class TemplateTextRegionConverter(documentContent: String, tokens: Seq[ITypedRegion]) {
+
+  private val tokenIndexLookup: Map[Int, ITypedRegion] = (tokens map (reg => (reg.getOffset(), reg))).toMap
+  private val scanner = new ScalaCodeScanner(TemplateTextRegionConverter.preferenceStore, ScalaVersions.Scala_2_10)
+  private val document = new SimpleDocument(documentContent)
+
+  def apply(token: ITypedRegion): (Seq[TemplateTextRegion], String) = {
+    if (token.getType == TemplatePartitions.TEMPLATE_SCALA)
+      computeScalaRegions(token)
+    else if (PartitionHelpers.isBrace(token, documentContent))
+      (List(new TemplateTextRegion(TemplateSyntaxClasses.BRACE, 0, token.getLength(), token.getLength())), TemplateDocumentRegions.SCALA_DOC_REGION)
+    else if (token.getType == TemplatePartitions.TEMPLATE_COMMENT)
+      (List(new TemplateTextRegion(TemplateSyntaxClasses.COMMENT, 0, token.getLength(), token.getLength())), TemplateDocumentRegions.COMMENT_DOC_REGION)
+    else if (PartitionHelpers.isCombinedBraceMagicAt(token, documentContent)) {
+      def isBrace(c: Char): Boolean = (c == '{' || c == '}')
+      val splitIndex = documentContent.indexWhere(isBrace, token.getOffset())
+      val braceLen = splitIndex - token.getOffset()
+      val magicAtLen = token.getLength() - braceLen
+      val brace = new TemplateTextRegion(TemplateSyntaxClasses.BRACE, 0, braceLen, braceLen)
+      val magicAt = new TemplateTextRegion(TemplateSyntaxClasses.MAGIC_AT, braceLen, magicAtLen, magicAtLen)
+      (List(brace, magicAt), TemplateDocumentRegions.SCALA_DOC_REGION)
+    } else (Nil, TemplateDocumentRegions.UNDEFINED)
+  }
+
+  private def computeScalaRegions(token: ITypedRegion): (Seq[TemplateTextRegion], String) = {
+    val regions = new ListBuffer[TemplateTextRegion]
+    var currentIndex = token.getOffset()
+    while (currentIndex < (token.getOffset() + token.getLength())) {
+      val t = tokenIndexLookup(currentIndex)
+      if (PartitionHelpers.isMagicAt(t, documentContent))
+        regions += new TemplateTextRegion(TemplateSyntaxClasses.MAGIC_AT, t.getOffset() - token.getOffset(), t.getLength(), t.getLength())
+      // actual scala code
+      else { //if (t.getType() == TemplatePartitions.TEMPLATE_SCALA) {
+        val tokens = scanner.tokenize(document, t.getOffset(), t.getLength())
+        tokens.foreach { v =>
+          regions += new TemplateTextRegion(v.syntaxClass, v.start - token.getOffset(), v.length, v.length)
+        }
+      }
+      currentIndex += t.getLength()
     }
-    
-    val ab = new ArrayBuffer[IStructuredDocumentRegion]
-    var current = resultRegions
-    while(current != null) {
-      ab += current
-      current = current.getNext() 
+
+    (regions, TemplateDocumentRegions.SCALA_DOC_REGION)
+  }
+}
+
+private object TemplateTextRegionConverter {
+  val preferenceStore = new ChainedPreferenceStore(Array((EditorsUI.getPreferenceStore()), PlayPlugin.preferenceStore))
+}
+
+// This is a copy and pasted implementation of AttributeNameRegion, with the only change being that adjustTextLength
+// actually adds the parameter to the field :). Had to reimplement the whole class because the fields in AttributeNameRegion are private
+class FixedAttributeNameRegion(start: Int, textLength: Int, length: Int) extends AttributeNameRegion(start, textLength, length) with HasLogger {
+  private var fLength: Int = length
+  private var fStart: Int = start
+  private var fTextLength: Int = textLength
+
+  override def adjustLength(i: Int) { fLength += i }
+  override def adjustStart(i: Int) { fStart += i }
+  override def adjustTextLength(i: Int) { fTextLength += i } // this is the only thing that's changed!!
+  override def equatePositions(region: ITextRegion) {
+    fStart = region.getStart
+    fLength = region.getLength
+    fTextLength = region.getTextLength
+  }
+  override def getEnd(): Int = fStart + fLength
+  override def getLength(): Int = fLength
+  override def getStart(): Int = fStart
+  override def getTextEnd(): Int = fStart + fTextLength
+  override def getTextLength(): Int = fTextLength
+  override def updateRegion(requester: AnyRef,
+    parent: IStructuredDocumentRegion,
+    changes: String,
+    requestStart: Int,
+    lengthToReplace: Int): StructuredDocumentEvent = {
+    var result: RegionChangedEvent = null
+    if (Debug.debugStructuredDocument) {
+      logger.debug("\t\tContextRegion::updateModel")
+      logger.debug("\t\t\tregion type is " + getType())
     }
-    
-    ab.result.toArray
+    var canHandle = false
+    canHandle = if ((changes == null) || (changes.length == 0)) if ((fStart >= getTextEnd) ||
+      (Math.abs(lengthToReplace) >= getTextEnd - getStart)) false else true
+    else if ((RegionUpdateRule.canHandleAsWhiteSpace(this,
+      parent, changes, requestStart, lengthToReplace)) ||
+      RegionUpdateRule.canHandleAsLetterOrDigit(this, parent, changes, requestStart, lengthToReplace)) true else false
+    if (canHandle) {
+      if (Debug.debugStructuredDocument) {
+        logger.debug("change handled by region")
+      }
+      val lengthDifference = Utilities.calculateLengthDifference(changes, lengthToReplace)
+      if (!RegionUpdateRule.canHandleAsWhiteSpace(this, parent, changes, requestStart, lengthToReplace)) {
+        fTextLength += lengthDifference
+      }
+      fLength += lengthDifference
+      result = new RegionChangedEvent(parent.getParentDocument, requester, parent, this, changes, requestStart,
+        lengthToReplace)
+    }
+    result
   }
 }

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/lexical/TemplateStructuredTextPartitioner.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/lexical/TemplateStructuredTextPartitioner.scala
@@ -41,7 +41,7 @@ class TemplateStructuredTextPartitioner extends StructuredTextPartitioner with I
   
   override def getPartitionType(region: ITextRegion, offset: Int) = {
     region match {
-      case scalaRegion: ScalaTextRegion => scalaRegion.syntaxClass match {
+      case scalaRegion: TemplateTextRegion => scalaRegion.syntaxClass match {
         case TemplateSyntaxClasses.COMMENT => TemplatePartitions.TEMPLATE_COMMENT
         case TemplateSyntaxClasses.MAGIC_AT => TemplatePartitions.TEMPLATE_PLAIN
         case TemplateSyntaxClasses.BRACE => TemplatePartitions.TEMPLATE_PLAIN

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/lexical/TemplateTextRegion.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/lexical/TemplateTextRegion.scala
@@ -3,5 +3,5 @@ package org.scalaide.play2.templateeditor.sse.lexical
 import scala.tools.eclipse.properties.syntaxcolouring.ScalaSyntaxClass
 import org.eclipse.wst.sse.core.internal.parser.ContextRegion
 
-case class ScalaTextRegion(val syntaxClass: ScalaSyntaxClass, newStart: Int, newTextLength: Int, newLength: Int)
+case class TemplateTextRegion(syntaxClass: ScalaSyntaxClass, newStart: Int, newTextLength: Int, newLength: Int)
   extends ContextRegion(syntaxClass.displayName, newStart, newTextLength, newLength)

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/style/ScalaLineStyleProvider.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/style/ScalaLineStyleProvider.scala
@@ -4,13 +4,13 @@ import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.wst.sse.core.internal.provisional.text.ITextRegion
 import org.eclipse.wst.sse.ui.internal.provisional.style.AbstractLineStyleProvider
 import org.eclipse.wst.sse.ui.internal.provisional.style.LineStyleProvider
-import org.scalaide.play2.templateeditor.sse.lexical.ScalaTextRegion
+import org.scalaide.play2.templateeditor.sse.lexical.TemplateTextRegion
 
 class ScalaLineStyleProvider(prefStore: IPreferenceStore) extends AbstractLineStyleProvider with LineStyleProvider {
   
    protected override def getAttributeFor(region: ITextRegion) = {
      region match {
-       case scalaRegion: ScalaTextRegion => {
+       case scalaRegion: TemplateTextRegion => {
          scalaRegion.syntaxClass.getTextAttribute(getColorPreferences)
        }
        case _ => null


### PR DESCRIPTION
These two commits fix issues https://github.com/scala-ide/scala-ide-play2/issues/167 and https://github.com/scala-ide/scala-ide-play2/issues/168. Please check out issue tickets for a more in-depth explanation of the problems.
