### PR TITLE
Fix for negative style ranges in Template editor.

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/templateeditor/sse/lexical/TemplateRegionParserTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/templateeditor/sse/lexical/TemplateRegionParserTest.scala
@@ -57,6 +57,16 @@ class TemplateRegionParserTest {
 
   private def addTextRegions(doc: IStructuredDocumentRegion, textRegions: Seq[ITextRegion]): Unit =
     textRegions.foreach(doc.addRegion(_))
+
+  @Test
+  def negativeStyleRange() = {
+    import scala.collection.JavaConverters._
+    val p = "@a() {\n\t<f\n\t@b.c()\n}"
+    val parser = new TemplateRegionParser
+    parser.reset(p)
+    for (region <- parser.templateRegions.textRegions.asScala)
+      assertTrue(s"ITextRegion found with negative text length: $region", region.getTextLength >= 0)
+  }
     
   @Test
   def reuseableCodeBlock() = {


### PR DESCRIPTION
When adjusting lengths and text lengths of ITextRegion, the adjustment to be made was based off of the region's length. However, it's possible that the text length is smaller than the normal length, so if the adjustment was negative, it could cause the text length to become negative.

Fixes #177
