### PR TITLE
Wrapped unsafe TemplateStructuredTextViewerConfiguration.scalaConfiguration in Option.

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/TemplateStructuredEditor.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/sse/TemplateStructuredEditor.scala
@@ -23,10 +23,8 @@ class TemplateStructuredEditor extends StructuredTextEditor with AbstractTemplat
    */
   override def setSourceViewerConfiguration(config: SourceViewerConfiguration) = {
     config match {
-      case templateConfig: TemplateStructuredTextViewerConfiguration => {
-        templateConfig.editor = this
-        templateConfig.prefStore = preferenceStore
-      }
+      case templateConfig: TemplateStructuredTextViewerConfiguration =>
+        templateConfig.initialize(preferenceStore, this)
       case _ =>
     }
     super.setSourceViewerConfiguration(config)


### PR DESCRIPTION
This prevents possible null pointer exceptions in other SSE component who create instances of this class, such as the Maven POM Editor.

Fixes #176
