### PR TITLE
Removed ScalaTemplateParser dependencies on scala-ide, ScalaTempalateCompiler, 2.10.x

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplateParsing.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/lexical/TemplateParsing.scala
@@ -1,21 +1,11 @@
 package org.scalaide.play2.templateeditor.lexical
 
 import scala.util.parsing.input.CharSequenceReader
-import play.templates.ScalaTemplateCompiler.Block
-import play.templates.ScalaTemplateCompiler.Comment
-import play.templates.ScalaTemplateCompiler.Def
-import play.templates.ScalaTemplateCompiler.Display
-import play.templates.ScalaTemplateCompiler.Plain
-import play.templates.ScalaTemplateCompiler.PosString
-import play.templates.ScalaTemplateCompiler.ScalaExp
-import play.templates.ScalaTemplateCompiler.ScalaExpPart
-import play.templates.ScalaTemplateCompiler.Simple
-import play.templates.ScalaTemplateCompiler.Template
-import play.templates.ScalaTemplateCompiler.TemplateTree
 import scala.util.parsing.input.Positional
 import scala.util.parsing.input.OffsetPosition
 import scala.util.parsing.input.NoPosition
 import play.templates.ScalaTemplateParser
+import play.templates.TreeNodes._
 
 /**
  * A helper for using tmeplate parser

--- a/org.scala-ide.play2/src/play/templates/ScalaTemplateCompiler.scala
+++ b/org.scala-ide.play2/src/play/templates/ScalaTemplateCompiler.scala
@@ -160,26 +160,9 @@ package play.templates {
   
   object ScalaTemplateCompiler {
 
-    import scala.util.parsing.input.Positional
+    import play.templates.TreeNodes._
     import scala.util.parsing.input.CharSequenceReader
     import scala.util.parsing.combinator.JavaTokenParsers
-
-    abstract class TemplateTree
-    abstract class ScalaExpPart
-
-    case class Params(code: String) extends Positional
-    case class Template(name: PosString, comment: Option[Comment], params: PosString, imports: Seq[Simple], defs: Seq[Def], sub: Seq[Template], content: Seq[TemplateTree]) extends Positional
-    case class PosString(str: String) extends Positional {
-      override def toString = str
-    }
-    case class Def(name: PosString, params: PosString, code: Simple) extends Positional
-    case class Plain(text: String) extends TemplateTree with Positional
-    case class Display(exp: ScalaExp) extends TemplateTree with Positional
-    case class Comment(msg: String) extends TemplateTree with Positional
-    case class ScalaExp(parts: Seq[ScalaExpPart]) extends TemplateTree with Positional
-    case class Simple(code: String) extends ScalaExpPart with Positional
-    case class Block(whitespace: String, args: Option[PosString], content: Seq[TemplateTree]) extends ScalaExpPart with Positional
-    case class Value(ident: PosString, block: Block) extends Positional
 
     def compile(source: File, sourceDirectory: File, generatedDirectory: File, resultType: String, formatterType: String, additionalImports: String = "", inclusiveDot: Boolean) = {
       val (templateName, generatedSource) = generatedFile(source, sourceDirectory, generatedDirectory, inclusiveDot)

--- a/org.scala-ide.play2/src/play/templates/ScalaTemplateParser.scala
+++ b/org.scala-ide.play2/src/play/templates/ScalaTemplateParser.scala
@@ -6,9 +6,7 @@ import scala.collection.mutable.ListBuffer
 import scala.util.parsing.input.OffsetPosition
 import scala.collection.mutable.Buffer
 import scala.collection.mutable.BufferLike
-import scala.reflect.ClassTag
 import scala.util.parsing.input.OffsetPosition
-import scala.tools.eclipse.logging.HasLogger
 import scala.annotation.elidable
 import scala.annotation.elidable._
 
@@ -91,16 +89,16 @@ import scala.annotation.elidable._
  *   - Invalid ("alone") '@' symbols. 
  */
 
-class ScalaTemplateParser(val shouldParseInclusiveDot: Boolean) extends HasLogger {
+class ScalaTemplateParser(val shouldParseInclusiveDot: Boolean) {
   
-  import ScalaTemplateCompiler._
+  import play.templates.TreeNodes._
   import scala.util.parsing.input.Positional
 
   sealed abstract class ParseResult
   case class Success(template: Template, input: Input) extends ParseResult
   case class Error(template: Template, input: Input, errors: List[PosString]) extends ParseResult
   
-  case class Input {
+  case class Input() {
     private var offset_ = 0
     private var source_ = ""
     private var length_ = 1
@@ -183,7 +181,7 @@ class ScalaTemplateParser(val shouldParseInclusiveDot: Boolean) extends HasLogge
     if (!input.isPastEOF(len) && input.matches(str)) 
       input.advance(len)
     else
-      error(s"Expected '$str' but found: '${(if (input.isPastEOF(len)) "EOF" else input(len))}'")
+      error("Expected '" + str + "' but found: '" + (if (input.isPastEOF(len)) "EOF" else input(len)) + "'")
   } 
   
   /** 
@@ -216,7 +214,7 @@ class ScalaTemplateParser(val shouldParseInclusiveDot: Boolean) extends HasLogge
   }
   
   def error(str: String): Unit = {
-    val error = PosString(s"[ERROR] $str.")
+    val error = PosString("[ERROR] " + str + ".")
     error.pos = input.pos
     errorStack += error
   }
@@ -301,8 +299,8 @@ class ScalaTemplateParser(val shouldParseInclusiveDot: Boolean) extends HasLogge
   }
   
   /** Match zero or more `parser` */
-  def several[T, BufferType <: Buffer[T]](parser: () => T, provided: BufferType = null)(implicit typetag: ClassTag[BufferType]): BufferType = {
-    val ab = if (provided != null) provided else typetag.runtimeClass.newInstance().asInstanceOf[BufferType]
+  def several[T, BufferType <: Buffer[T]](parser: () => T, provided: BufferType = null)(implicit manifest: Manifest[BufferType]): BufferType = {
+    val ab = if (provided != null) provided else manifest.erasure.newInstance().asInstanceOf[BufferType]
     var parsed = parser()
     while (parsed != null) {
       ab += parsed
@@ -814,10 +812,9 @@ class ScalaTemplateParser(val shouldParseInclusiveDot: Boolean) extends HasLogge
 
   }
 
-  @elidable(INFO)
-  def printRegressionStatistics() {
+  def mkRegressionStatisticsString() {
     val a = input.regressionStatistics.toArray.sortBy { case (m, (c, a)) => c }
-    logger.debug("[START REGRESSION STATISTICS]:\n" + a.mkString("\n") + "\n[END REGRESSION STATISTICS]")
+    a.mkString("\n")
   }
 
   // TODO - only for debugging purposes, remove before release

--- a/org.scala-ide.play2/src/play/templates/TreeNodes.scala
+++ b/org.scala-ide.play2/src/play/templates/TreeNodes.scala
@@ -1,0 +1,22 @@
+package play.templates
+
+import scala.util.parsing.input.Positional
+
+object TreeNodes {
+  abstract class TemplateTree
+  abstract class ScalaExpPart
+
+  case class Params(code: String) extends Positional
+  case class Template(name: PosString, comment: Option[Comment], params: PosString, imports: Seq[Simple], defs: Seq[Def], sub: Seq[Template], content: Seq[TemplateTree]) extends Positional
+  case class PosString(str: String) extends Positional {
+    override def toString = str
+  }
+  case class Def(name: PosString, params: PosString, code: Simple) extends Positional
+  case class Plain(text: String) extends TemplateTree with Positional
+  case class Display(exp: ScalaExp) extends TemplateTree with Positional
+  case class Comment(msg: String) extends TemplateTree with Positional
+  case class ScalaExp(parts: Seq[ScalaExpPart]) extends TemplateTree with Positional
+  case class Simple(code: String) extends ScalaExpPart with Positional
+  case class Block(whitespace: String, args: Option[PosString], content: Seq[TemplateTree]) extends ScalaExpPart with Positional
+  case class Value(ident: PosString, block: Block) extends Positional
+}


### PR DESCRIPTION
ScalaTemplateParser depended on:
- The TemplateTree classes in ScalaTempalteCompiler ==> These have been refactored to a separate file.
- HasLogger ==> Logging has simply been removed
- String interpolation ==> replaced with simple string concatenation [to make compatible with scala 2.9]
- ClassTags/TypeTags ==> replaced with deprecated Manifest [to make compatible with scala 2.9]

These changes are in preparation for when ScalaTemplateParser is split off into it's own project.
