### PR TITLE
Resolves a compilation error reported with 2.11

### DIFF
--- a/org.scala-ide.play2/src/play/templates/ScalaTemplateParser.scala
+++ b/org.scala-ide.play2/src/play/templates/ScalaTemplateParser.scala
@@ -100,7 +100,7 @@ class ScalaTemplateParser(val shouldParseInclusiveDot: Boolean) extends HasLogge
   case class Success(template: Template, input: Input) extends ParseResult
   case class Error(template: Template, input: Input, errors: List[PosString]) extends ParseResult
   
-  case class Input {
+  class Input {
     private var offset_ = 0
     private var source_ = ""
     private var length_ = 1


### PR DESCRIPTION
2.11 doesn't compile case classes without parameters anymore.
Because the case class is not needed it is changed to a normal class.
