### PR TITLE
Fixed source compatibility with Scala IDE master

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/quickassist/ControllerMethodResolver.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/quickassist/ControllerMethodResolver.scala
@@ -63,13 +63,14 @@ class ScalaControllerMethodResolver extends ControllerMethodResolver with ScalaP
 
         val response = new Response[Tree]
         comp.askTypeAt(pos, response)
-        for {
+        val controller = for {
           tree <- response.get.left.toOption
           sym = tree.symbol
           if isControllerMethod(sym)
         } yield ControllerMethod(sym.fullName, sym.paramss.flatten.map(param => (param.name.toString, param.tpe.toString)))
 
-      }(None)
+        controller.orNull
+      }
 
     case _ => None
   }

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessor.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessor.scala
@@ -31,12 +31,12 @@ class ActionContentAssistProcessor(routeEditor: HasScalaProject) extends IConten
   private def computeCompletionProposals(project: ScalaProject, viewer: ITextViewer, offset: Int): Array[ICompletionProposal] = {
     val document = viewer.getDocument
 
-    val completions = project.withPresentationCompiler { compiler =>
+    val completions = project.presentationCompiler { compiler =>
       compiler.askOption { () =>
         val computer = new ActionCompletionComputer(compiler)
         computer.computeCompletionProposals(document, offset)
       } getOrElse Nil
-    }()
+    } getOrElse Nil
 
     completions.sorted.toArray
   }

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateCompilationUnit.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/TemplateCompilationUnit.scala
@@ -82,16 +82,14 @@ case class TemplateCompilationUnit(_workspaceFile: IFile, val usesInclusiveDot: 
     new BatchSourceFile(templateSourceFile, contents)
   }
 
-  /** Return contents of generated scala file
-   */
+  /** Return contents of generated scala file. */
   override def getContents: Array[Char] = {
     withSourceFile({ (sourceFile, compiler) =>
       sourceFile.content
-    })(null)
+    }).orNull
   }
 
-  /** Return contents of template file
-   */
+  /** Return contents of template file. */
   def getTemplateContents: String = document.map(_.get).getOrElse(scalax.file.Path(file.file).string())
 
   override def currentProblems: List[IProblem] = {
@@ -119,8 +117,8 @@ case class TemplateCompilationUnit(_workspaceFile: IFile, val usesInclusiveDot: 
     playProject.withSourceFile(this)(op)
   }
 
-  override def withSourceFile[T](op: (SourceFile, ScalaPresentationCompiler) => T)(orElse: => T = scalaProject.defaultOrElse): T = {
-    playProject.withSourceFile(this)(op) getOrElse (orElse)
+  override def withSourceFile[T](op: (SourceFile, ScalaPresentationCompiler) => T): Option[T] = {
+    playProject.withSourceFile(this)(op)
   }
 
   /** maps a region in template file into generated scala file

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/compiler/TemplatePresentationCompiler.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/compiler/TemplatePresentationCompiler.scala
@@ -104,19 +104,19 @@ class TemplatePresentationCompiler(playProject: PlayProject) extends HasLogger {
     for (generatedSource <- tcu.generatedSource()) {
       val src = scalaFileFromGen(generatedSource)
       val sourceList = List(src)
-      scalaProject.withPresentationCompiler(pc => {
+      scalaProject.presentationCompiler (pc => {
         pc.withResponse((response: pc.Response[Unit]) => {
           pc.askReload(sourceList, response)
           response.get
         })
-      })()
+      })
     }
   }
 
   def withSourceFile[T](tcu: TemplateCompilationUnit)(op: (SourceFile, ScalaPresentationCompiler) => T): Option[T] =
-    scalaProject.withPresentationCompiler(pc => {
+    scalaProject.presentationCompiler(pc => {
       scalaFileFromTCU(tcu).map(op(_, pc)).toOption
-    })()
+    }).flatten
 
   def destroy() = {
     CompilerUsing.templateCompiler.TemplateAsFunctionCompiler.shutdownPresentationCompiler()

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/completion/CompletionProposalComputer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/completion/CompletionProposalComputer.scala
@@ -73,7 +73,8 @@ class CompletionProposalComputer extends ScalaCompletions with IContentAssistPro
       case Some(tcu) => {
         // FIXME: askReload doesn't (always) trigger a recompile
         tcu.askReload()
-        tcu.withSourceFile { findCompletions(viewer, offset, tcu) }(List[ICompletionProposal]()).toArray
+        val completions = tcu.withSourceFile { findCompletions(viewer, offset, tcu) } getOrElse Nil
+        completions.toArray
       }
       case _ => Array()
     }

--- a/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/hyperlink/LocalTemplateHyperlinkComputer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/templateeditor/hyperlink/LocalTemplateHyperlinkComputer.scala
@@ -61,7 +61,7 @@ class LocalTemplateHyperlinkComputer extends AbstractHyperlinkDetector {
                 }
               case _ => Nil
             }
-          }(Nil)
+          } getOrElse Nil
 
         case None => Nil
       }


### PR DESCRIPTION
Source compatibility with master was broken by this recent commit
scalaide/scalaide@cf73ce8. Furthermore, this patch depends on
https://github.com/scala-ide/scala-ide/pull/571

In fact, I expect the test `testScalaResolverNeg` to fail until the above mentioned PR is merged.
