### PR TITLE
Updates to be compatible with Scala IDE master

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn -Peclipse-juno -Pscala-ide-dev -Pscala-2.10.x clean verify
+mvn -Peclipse-kepler -Pscala-ide-nightly -Pscala-2.11.x clean verify

--- a/org.scala-ide.play2/META-INF/MANIFEST.MF
+++ b/org.scala-ide.play2/META-INF/MANIFEST.MF
@@ -40,7 +40,9 @@ Require-Bundle:
  org.eclipse.wst.validation;bundle-version="1.2.303",
  org.eclipse.wst.jsdt.web.ui;bundle-version="1.0.401",
  org.eclipse.wst.jsdt.web.core;bundle-version="1.0.401",
- org.eclipse.wst.jsdt.core;bundle-version="1.1.102"
+ org.eclipse.wst.jsdt.core;bundle-version="1.1.102",
+ org.scala-lang.modules.scala-xml,
+ org.scala-lang.modules.scala-parser-combinators
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter;apply-aspects:=false

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>plugin-profiles</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.5</version>
   </parent>
 
   <groupId>org.scala-ide</groupId>


### PR DESCRIPTION
Update to latest version of plugin-profiles to use Scala 2.11.1
Add direct dependency to scala-xml and scala-parser-combinators
