### PR TITLE
Play 2.4 support for action completion/hyperlinking in routes file

### DIFF
--- a/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessorTest.scala
+++ b/org.scala-ide.play2.tests/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessorTest.scala
@@ -143,10 +143,10 @@ class ActionContentAssistProcessorTest extends CompletionComputerTest {
   }
 
   @Test
-  def no_completion_for_scala_class_not_prefixed_with_@() {
+  def completion_for_scala_class() {
     val route = RouteCompletionFile { "GET / controllers.scala.AppCla#" }
 
-    route expectedCompletions ()
+    route expectedCompletions Proposal("AppClass", MemberKind.Class)
   }
 
   @Test
@@ -156,6 +156,13 @@ class ActionContentAssistProcessorTest extends CompletionComputerTest {
     route expectedCompletions Proposal("AppClass", MemberKind.Class)
   }
 
+  @Test
+  def completion_for_action_method_in_scala_class() {
+    val route = RouteCompletionFile { "GET / controllers.scala.AppClass.actionMe#" }
+
+    route expectedCompletions Proposal("actionMethod()", MemberKind.Def)
+  }
+  
   @Test
   def completion_for_action_method_in_scala_class_iff_prefixed_by_@() {
     val route = RouteCompletionFile { "GET / @controllers.scala.AppClass.actionMe#" }
@@ -192,10 +199,10 @@ class ActionContentAssistProcessorTest extends CompletionComputerTest {
   }
 
   @Test
-  def no_completion_for_NON_static_method_for_java_controller() {
+  def completion_for_NON_static_method_for_java_controller() {
     val route = RouteCompletionFile { "GET / controllers.java.Application.nonStaticMeth#" }
 
-    route expectedCompletions ()
+    route expectedCompletions Proposal("nonStaticMethod(name)", MemberKind.Def, isJava = true)
   }
 
   @Test
@@ -237,7 +244,7 @@ class ActionContentAssistProcessorTest extends CompletionComputerTest {
   def do_not_inherit_java_static_methods() {
     val route = RouteCompletionFile { "GET / controllers.java.SubApplication.#" }
 
-    route expectedCompletions ()
+    route expectedCompletions Proposal("nonStaticMethod(name)", MemberKind.Def, isJava = true)
   }
 
   @Test
@@ -322,6 +329,7 @@ class ActionContentAssistProcessorTest extends CompletionComputerTest {
     val route = RouteCompletionFile { "GET / controllers.scala.#" }
 
     route expectedCompletions (Proposal("ActionWithMangledName", MemberKind.Object),
+      Proposal("AppClass", MemberKind.Class),
       Proposal("AppNotExtendingController", MemberKind.Object),
       Proposal("MembersVisibility", MemberKind.Object),
       Proposal("SubAppClass", MemberKind.Object),
@@ -374,7 +382,7 @@ class ActionContentAssistProcessorTest extends CompletionComputerTest {
   def completion_for_top_level_scala_class() {
     val route = RouteCompletionFile { "GET / RootScalaApp#" }
     
-    route expectedCompletions Proposal("RootScalaApplication", MemberKind.Object)
+    route expectedCompletions (Proposal("RootScalaApplication", MemberKind.Object), Proposal("RootScalaApplication", MemberKind.Class))
   }
   
   @Test

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessor.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/ActionContentAssistProcessor.scala
@@ -34,8 +34,8 @@ class ActionContentAssistProcessor(routeEditor: HasScalaProject) extends IConten
     import org.scalaide.core.compiler.IScalaPresentationCompiler.Implicits._
     val completions = project.presentationCompiler { compiler =>
       compiler.asyncExec {
-        val computer = new ActionCompletionComputer(compiler)
-        computer.computeCompletionProposals(document, offset)
+        val actionComputer = new ActionCompletionComputer(compiler)
+        actionComputer.computeCompletionProposals(document, offset)
       }.getOrElse(Nil)()
     } getOrElse Nil
 

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/ActionCompletionComputer.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/ActionCompletionComputer.scala
@@ -19,7 +19,7 @@ class ActionCompletionComputer(compiler: IScalaPresentationCompiler) {
 
     val input = new ActionRouteInput(rawInput)
 
-    for {
+    val proposals: Set[ActionCompletionProposal] = (for {
       memberr <- MembersComputer(compiler, input).members
       // I need the cast because of path-dependent type mismatch. Feel free to suggest a fix, if you see one.
       member = memberr.asInstanceOf[compiler.Symbol]
@@ -27,7 +27,9 @@ class ActionCompletionComputer(compiler: IScalaPresentationCompiler) {
       if textReplacement.startsWith(input.suffix)
       kind = kindOf(member)
       isJava = !member.isPackage && member.isJava
-    } yield new ActionCompletionProposal(replaceRegion, textReplacement, kind, isJava)
+    } yield new ActionCompletionProposal(replaceRegion, textReplacement, kind, isJava))(collection.breakOut)
+
+    proposals.toList
   }
 
   /** Based on the passed `input` and its current `region` in the document, compute the

--- a/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/ActionCompletionProposal.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/routeeditor/completion/action/ActionCompletionProposal.scala
@@ -18,7 +18,7 @@ import org.eclipse.swt.graphics.Point
   * @param kind          The kind of member of this proposal, i.e., val, var, object, class, package, ...
   * @param isJava        Is this completion for a Java member.
   */
-class ActionCompletionProposal(replaceRegion: IRegion, val simpleName: String, val kind: MemberKind.Value, val isJava: Boolean)
+case class ActionCompletionProposal(replaceRegion: IRegion, val simpleName: String, val kind: MemberKind.Value, val isJava: Boolean)
   extends ICompletionProposal {
 
   import ActionCompletionProposal.javaFieldImage


### PR DESCRIPTION
Play 2.4 supports Dependency Injection (DI) -
https://www.playframework.com/documentation/2.4.x/Migration24#Dependency-Injection.
A consequence is that routes can now point to action's methods in either a
module or a class. To know if DI is used, we would have to check the project's
sbt build, and look at the value of the `routesGenerator` setting. If DI is
used, then action's methods in classes should be returned (together with
action's methods in modules, if present).

Unfortunately, it's not possible to check the value of `routesGenerator` in the
build, without having first-class sbt support in Eclipse. Because there is no
way to know whether a Play 2.4 project is using DI, the implemented solution
assumes that it may always be used. This is why both modules and classes members
are returned.

~~**Mind, I haven't monkey tested this patch, so you may want to give it a spin before merging :-)**~~
Alright, I've done some testing with a Scala Play 2.4 project, and it seems to be working fine