### PR TITLE
Bump version number to 0.5.0

### DIFF
--- a/org.scala-ide.play2.feature/feature.xml
+++ b/org.scala-ide.play2.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.scala-ide.play2.feature"
       label="Play2 support in Scala IDE"
-      version="0.4.6.qualifier"
+      version="0.5.0.qualifier"
       provider-name="Scala IDE"
       plugin="org.scala-ide.play2">
 

--- a/org.scala-ide.play2.feature/pom.xml
+++ b/org.scala-ide.play2.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.play2.build</artifactId>
-    <version>0.4.6-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.scala-ide.play2.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/org.scala-ide.play2.source.feature/feature.xml
+++ b/org.scala-ide.play2.source.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
   id="org.scala-ide.play2.source.feature"
   label="Play2 support in Scala IDE sources"
-  version="0.4.6.qualifier"
+  version="0.5.0.qualifier"
   provider-name="Scala IDE">
 
   <description url="http://github.com/scala-ide/scala-ide-play2/wiki">

--- a/org.scala-ide.play2.source.feature/pom.xml
+++ b/org.scala-ide.play2.source.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.play2.build</artifactId>
-    <version>0.4.6-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.scala-ide.play2.source.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/org.scala-ide.play2.tests/META-INF/MANIFEST.MF
+++ b/org.scala-ide.play2.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Plugin (Test)
 Bundle-SymbolicName: org.scala-ide.play2.tests
-Bundle-Version: 0.4.6.qualifier
+Bundle-Version: 0.5.0.qualifier
 Bundle-Vendor: scala-ide.org
 Fragment-Host: org.scala-ide.play2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/org.scala-ide.play2.tests/pom.xml
+++ b/org.scala-ide.play2.tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.play2.build</artifactId>
-    <version>0.4.6-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.scala-ide.play2.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>

--- a/org.scala-ide.play2.update-site/pom.xml
+++ b/org.scala-ide.play2.update-site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.play2.build</artifactId>
-    <version>0.4.6-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.scala-ide.play2.update-site</artifactId>
   <packaging>eclipse-update-site</packaging>

--- a/org.scala-ide.play2/META-INF/MANIFEST.MF
+++ b/org.scala-ide.play2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Play 2 Support for Scala IDE
 Bundle-SymbolicName: org.scala-ide.play2;singleton:=true
-Bundle-Version: 0.4.6.qualifier
+Bundle-Version: 0.5.0.qualifier
 Bundle-Vendor: scala-ide.org
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/org.scala-ide.play2/pom.xml
+++ b/org.scala-ide.play2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>org.scala-ide.play2.build</artifactId>
-    <version>0.4.6-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.scala-ide.play2</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>org.scala-ide</groupId>
   <artifactId>org.scala-ide.play2.build</artifactId>
-  <version>0.4.6-SNAPSHOT</version>
+  <version>0.5.0-SNAPSHOT</version>
   <name>Play 2 Support for Scala IDE</name>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
Command used to bump the version number:

```
mvn \
  -Peclipse-kepler,scala-ide-stable,scala-2.11.x \
  -Dtycho.mode=maven \
  org.eclipse.tycho:tycho-versions-plugin:set-version \
  -DnewVersion=0.5.0-SNAPSHOT
```