### PR TITLE
Make "add route entry" quick fix compatible to statistics tracker

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/quickassist/AddRouteEntryProposal.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/quickassist/AddRouteEntryProposal.scala
@@ -1,10 +1,14 @@
 package org.scalaide.play2.quickassist
 
-import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal
-import org.eclipse.swt.graphics.Image
 import org.eclipse.jface.text.IDocument
+
+import org.eclipse.swt.graphics.Image
+import org.scalaide.core.internal.statistics.Features.Feature
+import org.scalaide.core.internal.statistics.Groups.Editing
 import org.scalaide.core.quickassist.BasicCompletionProposal
 
-case class AddRouteEntryProposal(display: String, image: Image = null)(f: IDocument => Unit) extends BasicCompletionProposal(100, display, image) {
-  override def apply(doc: IDocument) = f(doc)
+object AddRouteEntry extends Feature("AddRouteEntry")("Add entry to route file", Editing)
+
+case class AddRouteEntryProposal(display: String, image: Image = null)(f: IDocument => Unit) extends BasicCompletionProposal(AddRouteEntry, 100, display, image) {
+  override def applyProposal(doc: IDocument) = f(doc)
 }


### PR DESCRIPTION
With the merge of the statistics tracker in Scala IDE, the quick fix
interface has changed and therefore produced a compilation error in the
play-ide.