### PR TITLE
Added play.mvc.Http.Context.Implicit._ to default template imports

### DIFF
--- a/org.scala-ide.play2/src/org/scalaide/play2/properties/PlayPreferences.scala
+++ b/org.scala-ide.play2/src/org/scalaide/play2/properties/PlayPreferences.scala
@@ -25,7 +25,8 @@ object PlayPreferences {
     "play.api.mvc._",
     "play.api.data._",
     "views.%format%._",
-    "play.api.templates.PlayMagic._")
+    "play.api.templates.PlayMagic._",
+    "play.mvc.Http.Context.Implicit._")
 
   final val defaultImports = serializeImports(DefaultTemplateImports.toArray)
 


### PR DESCRIPTION
The play! framework has play.mvc.Http.Context.Implicit._ among its default template imports, so I think it is a good idea to have them in the default imports for the template editor.

This way, the template editor will not mark as error the following (example):
ctx - ctx()
flash - flash()
session - session()