### PR TITLE
Fixes problem with malfunctioned closing of twirl template comments a…

### DIFF
--- a/org.scala-ide.play2.templates/src/org/scalaide/play2/templates/TemplateParser.scala
+++ b/org.scala-ide.play2.templates/src/org/scalaide/play2/templates/TemplateParser.scala
@@ -91,8 +91,21 @@ object TemplateParser {
       code.length
     case PosString(str) =>
       str.length
-    case Comment(str) =>
-      str.length + "@**@".length
+    case cm @ Comment(str) =>
+      import scala.util.parsing.input.OffsetPosition
+      val Open = "@*"
+      val Close = "*@"
+      val src = cm.pos match {
+        case op: OffsetPosition =>
+          val s = op.source.toString.slice(op.offset, op.offset + (Open + str + Close).length)
+          if (s.endsWith(Close))
+            s
+          else
+            Open + str
+        case _ =>
+          Open + str + Close
+      }
+      src.length
     case _ =>
       -1
   }


### PR DESCRIPTION
…ka @* comment *@. It needs still some

work because when incorrect document is closed and open then to run syntax coloring this document must
loose and gain the focus again.